### PR TITLE
Fix internal dependencies for packaging + remove floating-duration

### DIFF
--- a/physx/Cargo.toml
+++ b/physx/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "physx"
 description = "High-level Rust interface for Nvidia PhysX"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Embark <opensource@embark-studios.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/EmbarkStudios/physx-rs"

--- a/physx/Cargo.toml
+++ b/physx/Cargo.toml
@@ -14,19 +14,14 @@ categories = ["api-bindings", "simulation", "game-engines"]
 doctest = false
 
 [dependencies]
-# local dependency for testing
-#physx-macros = { path = "../physx-macros" }
-#physx-sys = { path = "../physx-sys" }
+physx-macros = { version = "0.1.0", path = "../physx-macros" }
+physx-sys = { version = "0.1.0", path = "../physx-sys" }
 
-# use this after publishing
-physx-macros = "0.1.0"
-physx-sys = "0.1.0"
-
-enumflags2 = "^0.5"
-enumflags2_derive = "^0.5"
+enumflags2 = "0.5"
+enumflags2_derive = "0.5"
 floating-duration = "0.1.2"
-nalgebra = "0.18.0"
-parking_lot = "0.9.0"
-ncollide3d = "0.20.1"
-nalgebra-glm = "0.4"
 log = "0.4"
+nalgebra = "0.18.0"
+nalgebra-glm = "0.4"
+ncollide3d = "0.20.1" # TODO: Remove, tracked in https://github.com/EmbarkStudios/physx-rs/issues/17
+parking_lot = "0.9.0"

--- a/physx/Cargo.toml
+++ b/physx/Cargo.toml
@@ -19,7 +19,6 @@ physx-sys = { version = "0.1.0", path = "../physx-sys" }
 
 enumflags2 = "0.5"
 enumflags2_derive = "0.5"
-floating-duration = "0.1.2"
 log = "0.4"
 nalgebra = "0.18.0"
 nalgebra-glm = "0.4"

--- a/physx/Cargo.toml
+++ b/physx/Cargo.toml
@@ -15,7 +15,7 @@ doctest = false
 
 [dependencies]
 physx-macros = { version = "0.1.0", path = "../physx-macros" }
-physx-sys = { version = "0.1.0", path = "../physx-sys" }
+physx-sys = { version = "0.1.1", path = "../physx-sys" }
 
 enumflags2 = "0.5"
 enumflags2_derive = "0.5"


### PR DESCRIPTION
`cargo package` wasn't working on the `physx` crate as we only specified path-dependencies. 

Fixed it so we specify both path and version dependencies which is the standard way to handle this. It will use the path dependencies when building the repo and the version dependency when packaging and for the published crate.