### PR TITLE
Fix Windows issue with generated structgen.obj file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 **/target
 Cargo.lock
-physx-sys/structgen.obj

--- a/physx-sys/Cargo.toml
+++ b/physx-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "physx-sys"
 description = "Unsafe bindings for NVIDIA PhysX C++ SDK"
-version = "0.1.1+4.1"
+version = "0.1.2+4.1"
 authors = ["Embark <opensource@embark-studios.com>", "Tomasz Stachowiak <h3@h3.gd>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/EmbarkStudios/physx-rs"
@@ -26,7 +26,6 @@ exclude = [
     "PhysX/**/*.sh",
     "PhysX/**/*.bat",
     "PhysX/**/*.html",
-    "structgen.obj",
 ]
 
 [lib]

--- a/physx-sys/build.rs
+++ b/physx-sys/build.rs
@@ -147,6 +147,11 @@ fn main() {
         let mut s = OsString::from("/Fe");
         s.push(&structgen_path);
         cmd.arg(s);
+
+        let mut s = OsString::from("/Fo");
+        s.push(&structgen_path);
+        s.push(".obj");
+        cmd.arg(s);
     } else {
         cmd.arg("-o").arg(&structgen_path);
     }

--- a/physx/Cargo.toml
+++ b/physx/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "physx"
 description = "High-level Rust interface for Nvidia PhysX"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Embark <opensource@embark-studios.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/EmbarkStudios/physx-rs"
@@ -15,7 +15,7 @@ doctest = false
 
 [dependencies]
 physx-macros = { version = "0.1.0", path = "../physx-macros" }
-physx-sys = { version = "0.1.1", path = "../physx-sys" }
+physx-sys = { version = "0.1.2", path = "../physx-sys" }
 
 enumflags2 = "0.5"
 enumflags2_derive = "0.5"


### PR DESCRIPTION
When `build.rs` was running on Windows with MSVC the structgen.cpp file generated a structgen.obj directly in physx-sys directory during the build which fails cargo packaging & publishing.

Now I force MSVC to put object file outputs in the output path.

Also bumped the crate versions because the previous version I had published included the structgen.obj file in the crate (!) which failed to build when syncing it down because Cargo stored it (correctly) as read-only.  So I had to yank those previously published releases today.

Kinda messy situation but glad to have found a simple solution for it, this is something that was an issue from the beginning (see #13) but think it only failed packaging/publishing correctly on Windows.