### PR TITLE
Update enumflags2 to 0.6

### DIFF
--- a/physx/Cargo.toml
+++ b/physx/Cargo.toml
@@ -17,8 +17,7 @@ doctest = false
 physx-macros = { version = "0.1.0", path = "../physx-macros" }
 physx-sys = { version = "0.1.2", path = "../physx-sys" }
 
-enumflags2 = "0.5"
-enumflags2_derive = "0.5"
+enumflags2 = "0.6"
 log = "0.4"
 nalgebra = "0.18.0"
 nalgebra-glm = "0.4"

--- a/physx/src/actor.rs
+++ b/physx/src/actor.rs
@@ -11,7 +11,6 @@ Trait for PxActor
 
 use super::{base::Base, math::*, px_type::*};
 use enumflags2::*;
-use enumflags2_derive::*;
 use physx_macros::*;
 use physx_sys::{
     PxActor, PxActorFlag, PxActorFlags, PxActorType, PxActor_getActorFlags, PxActor_getAggregate,
@@ -30,7 +29,7 @@ use physx_sys::{
  * Section ENUMS                                                               *
  ******************************************************************************/
 
-#[derive(Debug, Copy, Clone, EnumFlags)]
+#[derive(Debug, Copy, Clone, BitFlags)]
 #[repr(u8)]
 pub enum ActorFlag {
     Visualization = 1,

--- a/physx/src/articulation_cache.rs
+++ b/physx/src/articulation_cache.rs
@@ -14,7 +14,6 @@ use super::{
     transform::{na_to_px_q, na_to_px_v3, px_to_na_q, px_to_na_v3},
 };
 use enumflags2::BitFlags;
-use enumflags2_derive::EnumFlags;
 use nalgebra_glm as glm;
 use physx_sys::{
     PxArticulationCache, PxArticulationCacheFlags, PxArticulationRootLinkData, PxTransform_new_5,
@@ -24,7 +23,7 @@ use physx_sys::{
 // Section ENUMS
 ////////////////////////////////////////////////////////////////////////////////
 
-#[derive(Debug, Clone, Copy, EnumFlags)]
+#[derive(Debug, Clone, Copy, BitFlags)]
 #[repr(u8)]
 pub enum ArticulationCacheFlag {
     Velocity = 1,

--- a/physx/src/base.rs
+++ b/physx/src/base.rs
@@ -4,7 +4,6 @@ Wrapper for PxBase.
 
 use super::px_type::*;
 use enumflags2::BitFlags;
-use enumflags2_derive::*;
 use physx_macros::physx_type;
 use physx_sys::{
     PxBase, PxBaseFlag, PxBaseFlags, PxBase_getBaseFlags, PxBase_getConcreteType,
@@ -16,7 +15,7 @@ use physx_sys::{
  * Section ENUMERATIONS                                                        *
  ******************************************************************************/
 
-#[derive(Copy, Clone, EnumFlags, Debug)]
+#[derive(Copy, Clone, BitFlags, Debug)]
 #[repr(u16)]
 pub enum BaseFlag {
     OwnsMemory = 1,

--- a/physx/src/foundation.rs
+++ b/physx/src/foundation.rs
@@ -12,11 +12,10 @@ Wrapper for PxFoundation class
 use super::px_type::*;
 use super::traits::*;
 use enumflags2::BitFlags;
-use enumflags2_derive::EnumFlags;
 use physx_macros::*;
 use physx_sys::*;
 
-#[derive(EnumFlags, Copy, Clone, Debug, PartialEq)]
+#[derive(BitFlags, Copy, Clone, Debug, PartialEq)]
 #[repr(u32)]
 pub enum ErrorCode {
     DebugInfo = 1u32,

--- a/physx/src/heightfield.rs
+++ b/physx/src/heightfield.rs
@@ -13,7 +13,6 @@ use super::{
     geometry::Geometry,
 };
 use enumflags2::BitFlags;
-use enumflags2_derive::EnumFlags;
 use nalgebra_glm as glm;
 use ncollide3d::procedural::{quad_with_vertices, TriMesh};
 use physx_sys::*;
@@ -24,7 +23,7 @@ pub enum HeightfieldFormat {
     S16TM = 1,
 }
 
-#[derive(EnumFlags, Debug, Copy, Clone)]
+#[derive(BitFlags, Debug, Copy, Clone)]
 #[repr(u16)]
 pub enum HeightfieldFlag {
     NoboundaryEdges = 1,

--- a/physx/src/rigid_body.rs
+++ b/physx/src/rigid_body.rs
@@ -10,7 +10,6 @@
 */
 use super::{px_type::*, rigid_actor::RigidActor, transform::*};
 use enumflags2::*;
-use enumflags2_derive::*;
 use nalgebra_glm as glm;
 use physx_macros::*;
 use physx_sys::{
@@ -36,7 +35,7 @@ use physx_sys::{
  * Section ENUMERATIONS                                                        *
  ******************************************************************************/
 
-#[derive(Debug, Copy, Clone, EnumFlags)]
+#[derive(Debug, Copy, Clone, BitFlags)]
 #[repr(u8)]
 pub enum RigidBodyFlag {
     Kinematic = 1,

--- a/physx/src/scene.rs
+++ b/physx/src/scene.rs
@@ -21,7 +21,7 @@ use super::{
     user_data::UserData,
     visual_debugger::*,
 };
-use enumflags2_derive::EnumFlags;
+use enumflags2::BitFlags;
 use nalgebra_glm as glm;
 
 use physx_sys::*;
@@ -435,7 +435,7 @@ impl Scene {
     }
 }
 
-#[derive(Debug, Clone, Copy, EnumFlags)]
+#[derive(Debug, Clone, Copy, BitFlags)]
 #[repr(u32)]
 pub enum BroadPhaseType {
     SweepAndPrune = 1,

--- a/physx/src/shape.rs
+++ b/physx/src/shape.rs
@@ -11,7 +11,6 @@ Wrapper for PxShape
 
 use super::{base::Base, px_type::*, traits::*};
 use enumflags2::BitFlags;
-use enumflags2_derive::EnumFlags;
 use physx_macros::*;
 use physx_sys::{
     PxFilterData, PxFilterData_new_1, PxMaterial, PxMaterial_release_mut, PxShape, PxShapeFlag,
@@ -21,7 +20,7 @@ use physx_sys::{
 };
 
 /// Layers used for collision/querying of shapes
-#[derive(Debug, Copy, Clone, EnumFlags)]
+#[derive(Debug, Copy, Clone, BitFlags)]
 #[repr(u32)]
 pub enum CollisionLayer {
     Ghost = 1,
@@ -31,7 +30,7 @@ pub enum CollisionLayer {
 }
 
 /// Layers used for collision/querying of shapes
-#[derive(Debug, Copy, Clone, EnumFlags)]
+#[derive(Debug, Copy, Clone, BitFlags)]
 #[repr(u32)]
 pub enum ShapeFlag {
     SimulationShape = 1u32,

--- a/physx/src/visual_debugger.rs
+++ b/physx/src/visual_debugger.rs
@@ -11,12 +11,11 @@
 
 use super::{foundation::*, px_type::*, traits::*};
 use enumflags2::BitFlags;
-use enumflags2_derive::EnumFlags;
 use log::*;
 use physx_macros::*;
 use physx_sys::*;
 
-#[derive(EnumFlags, Copy, Clone, Debug, PartialEq)]
+#[derive(BitFlags, Copy, Clone, Debug, PartialEq)]
 #[repr(u8)]
 pub enum VisualDebuggerSceneFlag {
     TransmitContacts = 1,


### PR DESCRIPTION
This drops a transitive dependency on pre-1.0 `syn`, which
should improve compile times.

I wasn't able to compile the `-sys` crate locally, so I'm going to make use of your CI :)