### PR TITLE
Upgrade glam 0.7 -> 0.8

### DIFF
--- a/physx/Cargo.toml
+++ b/physx/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "physx"
 description = "High-level Rust interface for Nvidia PhysX"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Embark <opensource@embark-studios.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/EmbarkStudios/physx-rs"
@@ -19,5 +19,5 @@ physx-sys = { version = "0.1", path = "../physx-sys" }
 
 enumflags2 = "0.6"
 log = "0.4"
-glam = "0.7"
+glam = "0.8"
 parking_lot = "0.9.0"

--- a/physx/src/math/mod.rs
+++ b/physx/src/math/mod.rs
@@ -43,7 +43,7 @@ impl Isometry {
         );
         assert!(x.w() == 0.0 && y.w() == 0.0 && z.w() == 0.0, "Unable to extract the rotation matrix because one of the W components of the axis wasn't 0.0");
 
-        let rotation = Mat4::new(x, y, z, Vec4::unit_w());
+        let rotation = Mat4::from_cols(x, y, z, Vec4::unit_w());
         let translation = Mat4::from_translation(m.w_axis().truncate());
         Self {
             rotation,
@@ -55,12 +55,12 @@ impl Isometry {
 #[cfg(test)]
 mod tests {
     use super::Isometry;
-    use glam::f32::{deg, Mat4, Vec3};
+    use glam::f32::{Mat4, Vec3};
     #[test]
     fn isometry() {
-        let rot_z = Mat4::from_rotation_z(deg(40.0));
-        let rot_y = Mat4::from_rotation_y(deg(30.0));
-        let rot_x = Mat4::from_rotation_x(deg(20.0));
+        let rot_z = Mat4::from_rotation_z(40.0);
+        let rot_y = Mat4::from_rotation_y(30.0);
+        let rot_x = Mat4::from_rotation_x(20.0);
         let rot = rot_y * rot_x * rot_z;
         let trans = Mat4::from_translation(Vec3::new(1.0, 2.0, 3.0));
         let m = trans * rot;

--- a/physx/src/math/mod.rs
+++ b/physx/src/math/mod.rs
@@ -58,9 +58,9 @@ mod tests {
     use glam::f32::{Mat4, Vec3};
     #[test]
     fn isometry() {
-        let rot_z = Mat4::from_rotation_z(40.0);
-        let rot_y = Mat4::from_rotation_y(30.0);
-        let rot_x = Mat4::from_rotation_x(20.0);
+        let rot_z = Mat4::from_rotation_z(f32::to_radians(40.0));
+        let rot_y = Mat4::from_rotation_y(f32::to_radians(30.0));
+        let rot_x = Mat4::from_rotation_x(f32::to_radians(20.0));
         let rot = rot_y * rot_x * rot_z;
         let trans = Mat4::from_translation(Vec3::new(1.0, 2.0, 3.0));
         let m = trans * rot;

--- a/physx/src/rigid_actor.rs
+++ b/physx/src/rigid_actor.rs
@@ -21,7 +21,7 @@ use super::{
     user_data::UserData,
 };
 use enumflags2::BitFlags;
-use glam::{Angle, Mat4, Vec3};
+use glam::{Mat4, Vec3};
 use physx_macros::physx_type;
 use physx_sys::{
     phys_PxGetPhysics, PxContactPair, PxContactPairPoint, PxContactPair_extractContacts,
@@ -132,9 +132,9 @@ impl RigidActor {
 
         unsafe {
             let mtrl = PxPhysics_createMaterial_mut(phys_PxGetPhysics(), 0.9, 0.9, 0.0);
-            let angle: f32 = -90.0;
+            let angle = f32::to_radians(-90.0);
             let rotation = if geometry.get_type() == GeometryType::Capsule {
-                Mat4::from_axis_angle(Vec3::unit_y(), Angle::from_degrees(angle))
+                Mat4::from_axis_angle(Vec3::unit_y(), angle)
             } else {
                 Mat4::identity()
             };


### PR DESCRIPTION
0.8 includes two `glam` fixes/changes that we filed and @bitshifter implemented:
- https://github.com/bitshifter/glam-rs/issues/22
- https://github.com/bitshifter/glam-rs/issues/21

Bumped the minor verison of `physx` here as we use `glam` in the public API of the crate