### PR TITLE
Upgrade to PhysX 4.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This repository contains 3 crates:
 The following code example shows how [`physx`](physx/) can be initialized.
 
 ``` Rust
-const PX_PHYSICS_VERSION: u32 = physx::version(4, 1, 0);
+const PX_PHYSICS_VERSION: u32 = physx::version(4, 1, 1);
 let mut foundation = Foundation::new(PX_PHYSICS_VERSION);
 
 let mut physics = PhysicsBuilder::default()

--- a/physx-sys/Cargo.toml
+++ b/physx-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "physx-sys"
 description = "Unsafe bindings for NVIDIA PhysX C++ SDK"
-version = "0.1.2+4.1"
+version = "0.2.0+4.1.1"
 authors = ["Embark <opensource@embark-studios.com>", "Tomasz Stachowiak <h3@h3.gd>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/EmbarkStudios/physx-rs"

--- a/physx-sys/build.rs
+++ b/physx-sys/build.rs
@@ -101,16 +101,8 @@ fn main() {
     println!("cargo:rustc-link-lib=static=PhysXPvdSDK_static_64");
     println!("cargo:rustc-link-lib=static=PhysXCommon_static_64");
     println!("cargo:rustc-link-lib=static=PhysXFoundation_static_64");
-
-    if "mac" == target_os {
-        // PhysX's lib names don't include the "static" segment on Mac, even though they are indeed static.
-        // See `PHYSXEXTENSIONS_LIBTYPE` in PhysX's cmake definitions for more details.
-        println!("cargo:rustc-link-lib=static=PhysXCharacterKinematic_64");
-        println!("cargo:rustc-link-lib=static=PhysXExtensions_64");
-    } else {
-        println!("cargo:rustc-link-lib=static=PhysXCharacterKinematic_static_64");
-        println!("cargo:rustc-link-lib=static=PhysXExtensions_static_64");
-    }
+    println!("cargo:rustc-link-lib=static=PhysXCharacterKinematic_static_64");
+    println!("cargo:rustc-link-lib=static=PhysXExtensions_static_64");
 
     let mut cc_builder = cc::Build::new();
     let physx_cc = cc_builder

--- a/physx/Cargo.toml
+++ b/physx/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "physx"
 description = "High-level Rust interface for Nvidia PhysX"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Embark <opensource@embark-studios.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/EmbarkStudios/physx-rs"
@@ -15,7 +15,7 @@ doctest = false
 
 [dependencies]
 physx-macros = { version = "0.1", path = "../physx-macros" }
-physx-sys = { version = "0.1", path = "../physx-sys" }
+physx-sys = { version = "0.2", path = "../physx-sys" }
 
 enumflags2 = "0.6"
 log = "0.4"

--- a/physx/README.md
+++ b/physx/README.md
@@ -22,7 +22,7 @@ Please also see the [repository](https://github.com/EmbarkStudios/physx-rs) cont
 ## Basic usage
 
 ``` rust
-const PX_PHYSICS_VERSION: u32 = physx::version(4, 1, 0);
+const PX_PHYSICS_VERSION: u32 = physx::version(4, 1, 1);
 let mut foundation = Foundation::new(PX_PHYSICS_VERSION);
 
 let mut physics = PhysicsBuilder::default()

--- a/physx/examples/ball_physx.rs
+++ b/physx/examples/ball_physx.rs
@@ -5,7 +5,7 @@
 use glam::{Mat4, Vec3};
 use physx::prelude::*;
 
-const PX_PHYSICS_VERSION: u32 = physx::version(4, 1, 0);
+const PX_PHYSICS_VERSION: u32 = physx::version(4, 1, 1);
 
 /// This is a WIP example for how the rustified wrappers lets your reduced the
 /// amount of unsafe in your code, and make it clearer where we cannot abstract

--- a/physx/src/lib.rs
+++ b/physx/src/lib.rs
@@ -29,7 +29,7 @@
 //! ## Basic usage
 //!
 //! ``` rust
-//! const PX_PHYSICS_VERSION: u32 = physx::version(4, 1, 0);
+//! const PX_PHYSICS_VERSION: u32 = physx::version(4, 1, 1);
 //! let mut foundation = Foundation::new(PX_PHYSICS_VERSION);
 //!
 //! let mut physics = PhysicsBuilder::default()


### PR DESCRIPTION
Upgrade to latest available version of PhysX, 4.1.1.27006925.

Will publish this release and then do a follow up patch release that switches it to use our fork of 4.1.1 that fixes Xcode 11 support (https://github.com/NVIDIAGameWorks/PhysX/pull/185) for #23 