### PR TITLE
Fix build issues with vs2019

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-2016, macOS-latest]
+        os: [ubuntu-latest, windows-2016, windows-2019, macOS-latest]
     env:
       DEVELOPER_DIR: /Applications/Xcode_11.1.app
     runs-on: ${{ matrix.os }}

--- a/physx-sys/Cargo.toml
+++ b/physx-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "physx-sys"
 description = "Unsafe bindings for NVIDIA PhysX C++ SDK"
-version = "0.2.1+4.1.1"
+version = "0.2.2+4.1.1"
 authors = ["Embark <opensource@embark-studios.com>", "Tomasz Stachowiak <h3@h3.gd>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/EmbarkStudios/physx-rs"

--- a/physx-sys/build.rs
+++ b/physx-sys/build.rs
@@ -3,8 +3,14 @@ use std::env;
 use std::ffi::OsString;
 use std::path::PathBuf;
 
-fn get_target_os() -> String {
-    env::var("CARGO_CFG_TARGET_OS").unwrap()
+fn get_physx_target_os_name() -> String {
+    let os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    match os.as_str() {
+        // CARGO_CFG_TARGET_OS uses "linux", "windows", and "macos"
+        // PhysX uses "linux", "windows", and "mac"
+        "macos" => "mac".to_owned(),
+        _ => os,
+    }
 }
 
 // Find the time of the most recent modification among all the files in a directory
@@ -116,7 +122,7 @@ fn main() {
         "profile"
     };
 
-    let target_os = get_target_os();
+    let target_os = get_physx_target_os_name();
     let target_os = target_os.as_str();
     let mut physx_cfg = Config::new("PhysX/physx/source/compiler/cmake");
 

--- a/physx-sys/build.rs
+++ b/physx-sys/build.rs
@@ -45,7 +45,7 @@ fn most_recent_modification_time_in_dir(path: &PathBuf) -> Option<std::time::Sys
 fn locate_output_lib_dir(mut cmake_build_out: PathBuf, build_profile: &str) -> String {
     use std::fs;
 
-    // Always witin the "bin" folder of the CMAKE output
+    // Always within the "bin" folder of the CMAKE output
     cmake_build_out.push("bin");
 
     if let Ok(entries) = fs::read_dir(&cmake_build_out) {

--- a/physx-sys/build.rs
+++ b/physx-sys/build.rs
@@ -66,7 +66,10 @@ fn locate_output_lib_dir(mut cmake_build_out: PathBuf, build_profile: &str) -> S
             .max_by_key(|(_, m)| m.clone())
             .map(|(d, _)| d);
 
-        out_dir.expect("could not locate output directory for PhysX static libs").display().to_string()
+        out_dir
+            .expect("could not locate output directory for PhysX static libs")
+            .display()
+            .to_string()
     } else {
         panic!("Could not inspect cmake build output directory");
     }


### PR DESCRIPTION
Fixes #35 and missing typeinfo.h issues with Visual Studio 2019.

The linker error was caused by the wrong directory being used for build static libs. It is now discovered automatically by the `build.rs` script.

The PhysX submodule is updated to point to our fork which now includes a workaround for the missing include file.

Includes Visual Studio 2019 CI build config from #36.