### PR TITLE
Fix cargo publish by removing PxConfig.h at the end of build.rs

### DIFF
--- a/physx-sys/build.rs
+++ b/physx-sys/build.rs
@@ -235,4 +235,7 @@ fn main() {
 
     // TODO: use the cloned git revision number instead
     println!("cargo:rerun-if-changed=PhysX/physx/include/PxPhysicsVersion.h");
+
+    // Remove PxConfig.h since we're only allowed to modify OUT_DIR.
+    let _ = std::fs::remove_file(physx_root_dir.join("include/PxConfig.h"));
 }


### PR DESCRIPTION
PxConfig.h is generated in the source directories by PhysX's build system. This upsets cargo, so let's just delete the file after the build is done.