### PR TITLE
respect CC and CXX environment variables

### DIFF
--- a/physx-sys/build.rs
+++ b/physx-sys/build.rs
@@ -142,8 +142,14 @@ fn main() {
         .define("PX_GENERATE_STATIC_LIBRARIES", "True")
         .define("PX_GENERATE_GPU_PROJECTS", "False")
         .define("TARGET_BUILD_PLATFORM", target_os)
-        .define("CMAKE_C_COMPILER", "clang")
-        .define("CMAKE_CXX_COMPILER", "clang++")
+        .define(
+            "CMAKE_C_COMPILER",
+            env::var("CC").unwrap_or("clang".to_owned()),
+        )
+        .define(
+            "CMAKE_CXX_COMPILER",
+            env::var("CXX").unwrap_or("clang++".to_owned()),
+        )
         .define("CMAKE_BUILD_TYPE", build_mode)
         .profile(build_mode)
         .build();
@@ -184,7 +190,7 @@ fn main() {
     // generally be picked up as the default C++ compiler over clang.
     // This should be host_os, but we don't cross compile
     if target_os == "linux" {
-        physx_cc.compiler("clang++");
+        physx_cc.compiler(env::var("CXX").unwrap_or("clang++".to_owned()));
     }
 
     let mut structgen_path = output_dir_path.join("structgen");


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

All my clang binaries are named by version since I have multiple, and as the build script specifically targets `clang++` it fails. This change makes the build script read the `CC` and `CXX` environment variables at the appropriate locations while still defaulting to clang/++ as before, which provides a way to correct the compiler identification.

* Everywhere a C++ compiler is required, use `$CXX` before `clang++`
* Everywhere a C compiler is required, use `$CC` before `clang`