### PR TITLE
Added lifetime to HeightfieldSampler so that it can capture non-static variables

### DIFF
--- a/physx/src/controller.rs
+++ b/physx/src/controller.rs
@@ -1,0 +1,59 @@
+#![warn(clippy::all)]
+#![warn(rust_2018_idioms)]
+
+use glam::Vec3;
+use physx_sys::{
+    PxController, PxController_getPosition, PxController_release_mut, PxController_setPosition_mut,
+    PxExtendedVec3,
+};
+
+pub struct Controller {
+    controller: *mut PxController,
+}
+
+impl Controller {
+    pub fn new(controller: *mut PxController) -> Self {
+        Self { controller }
+    }
+
+    pub fn get_raw_mut(&mut self) -> *mut PxController {
+        self.controller
+    }
+
+    pub fn get_raw(&mut self) -> *const PxController {
+        self.controller
+    }
+
+    pub fn set_position(&mut self, position: Vec3) {
+        unsafe {
+            PxController_setPosition_mut(self.get_raw_mut(), &(to_extended(&position)));
+        }
+    }
+
+    pub fn get_position(&mut self) -> Vec3 {
+        unsafe { from_extended(*PxController_getPosition(self.get_raw_mut())) }
+    }
+    pub fn release(&mut self) {
+        unsafe {
+            PxController_release_mut(self.get_raw_mut());
+        }
+    }
+}
+
+impl Drop for Controller {
+    fn drop(&mut self) {
+        self.release()
+    }
+}
+
+fn to_extended(vec: &Vec3) -> PxExtendedVec3 {
+    PxExtendedVec3 {
+        x: vec.x() as f64,
+        y: vec.y() as f64,
+        z: vec.z() as f64,
+    }
+}
+
+fn from_extended(vec: PxExtendedVec3) -> Vec3 {
+    Vec3::new(vec.x as f32, vec.y as f32, vec.z as f32)
+}

--- a/physx/src/cooking.rs
+++ b/physx/src/cooking.rs
@@ -71,8 +71,13 @@ impl Cooking {
         &self,
         heightfield_desc: PxHeightFieldDesc,
         double_sided: bool,
+        width: f32,
+        length: f32,
+        height: f32,
     ) -> Geometry {
         unsafe {
+            let x_scale = width;
+            let y_scale = length;
             let insertion_callback = PxPhysics_getPhysicsInsertionCallback_mut(phys_PxGetPhysics());
 
             let heightfield =
@@ -88,9 +93,9 @@ impl Cooking {
                 PxMeshGeometryFlags {
                     mBits: mesh_flags as u8,
                 },
-                HEIGHT_SCALE,
-                XZ_SCALE,
-                XZ_SCALE,
+                height / 2.0_f32.powf(15.0),
+                x_scale,
+                y_scale,
             );
 
             Geometry::HeightField(heightfield_geom)

--- a/physx/src/heightfield.rs
+++ b/physx/src/heightfield.rs
@@ -28,10 +28,10 @@ pub enum HeightfieldFlag {
     NoboundaryEdges = 1,
 }
 
-pub type HeightfieldSampler = dyn Fn(usize, usize) -> f32;
+pub type HeightfieldSampler<'a> = dyn Fn(usize, usize) -> f32 + 'a;
 
 pub struct HeightfieldBuilder<'a> {
-    sampler: &'a HeightfieldSampler,
+    sampler: &'a HeightfieldSampler<'a>,
     size: (usize, usize),
     edge_threshold: f32,
     format: HeightfieldFormat,
@@ -51,7 +51,7 @@ impl<'a> Default for HeightfieldBuilder<'a> {
 }
 
 impl<'a> HeightfieldBuilder<'a> {
-    pub fn sampler(self, sampler: &'a HeightfieldSampler) -> Self {
+    pub fn sampler(self, sampler: &'a HeightfieldSampler<'a>) -> Self {
         Self { sampler, ..self }
     }
 

--- a/physx/src/lib.rs
+++ b/physx/src/lib.rs
@@ -116,6 +116,7 @@ pub mod articulation_link;
 pub mod articulation_reduced_coordinate;
 pub mod base;
 pub mod body;
+pub mod controller;
 pub mod cooking;
 pub mod foundation;
 pub mod geometry;

--- a/physx/src/prelude.rs
+++ b/physx/src/prelude.rs
@@ -20,6 +20,7 @@ pub use super::articulation_link::ArticulationLink;
 pub use super::articulation_reduced_coordinate::ArticulationReducedCoordinate;
 pub use super::base::Base;
 pub use super::body::*;
+pub use super::controller::Controller;
 pub use super::cooking::*;
 pub use super::foundation::*;
 pub use super::geometry::*;


### PR DESCRIPTION
Without this annotation, the lifetime elision assumes that everything is captured using the 'static lifetime. This doesn't work if you want to create a function that passes in a non-static array of height values. 

For example: 

```rust
pub fn create_terrain(
    transform: Mat4,
    xsize: usize,
    ysize: usize,
    heights: &[f32],

) {

    let builder: HeightfieldBuilder = HeightfieldBuilder::default();
    let sampler: &(dyn Fn(usize, usize) -> f32) = &|x, y| heights[x*ysize+y];
    let terrain_geo = builder
        .size(xsize, ysize)
        .sampler(sampler)
        .build(&mut self.physx.cooking)
}
```

This code would fail before, with the cryptic error message that `heights` requires an explicit lifetime of 'static, but will compile with this patch. 