### PR TITLE
Using PxVec3 in triangle meshes, so the sizes match up

### DIFF
--- a/physx/src/articulation_reduced_coordinate.rs
+++ b/physx/src/articulation_reduced_coordinate.rs
@@ -106,7 +106,7 @@ impl ArticulationReducedCoordinate {
         }
 
         if let Some(ref collider) = builder.collider {
-            let geometry = cooking.make_geometry(collider.clone());
+            let geometry = cooking.make_geometry(collider.clone(), Vec3::new(1.0, 1.0, 1.0));
             link.create_exclusive_shape(geometry, Mat4::identity(), Mat4::identity());
         }
 

--- a/physx/src/articulation_reduced_coordinate.rs
+++ b/physx/src/articulation_reduced_coordinate.rs
@@ -106,7 +106,7 @@ impl ArticulationReducedCoordinate {
         }
 
         if let Some(ref collider) = builder.collider {
-            let geometry = cooking.make_geometry(collider.clone(), Vec3::new(1.0, 1.0, 1.0));
+            let geometry = cooking.make_geometry(collider.clone());
             link.create_exclusive_shape(geometry, Mat4::identity(), Mat4::identity());
         }
 

--- a/physx/src/cooking.rs
+++ b/physx/src/cooking.rs
@@ -100,7 +100,7 @@ impl Cooking {
         }
     }
 
-    pub fn make_geometry(&mut self, desc: ColliderDesc, mesh_scale: Vec3) -> PhysicsGeometry {
+    pub fn make_geometry(&mut self, desc: ColliderDesc) -> PhysicsGeometry {
         let geometry: Geometry = unsafe {
             match desc {
                 ColliderDesc::Sphere(radius) => Geometry::Sphere(PxSphereGeometry_new_1(radius)),
@@ -111,7 +111,11 @@ impl Cooking {
                 ColliderDesc::Cylinder(r, h) => {
                     Geometry::Capsule(PxCapsuleGeometry_new_1(r, h / 2.0))
                 }
-                ColliderDesc::TriMesh { vertices, indices } => {
+                ColliderDesc::TriMesh {
+                    vertices,
+                    indices,
+                    mesh_scale,
+                } => {
                     let mut mesh_desc = PxTriangleMeshDesc_new();
 
                     mesh_desc.points.count = vertices.len() as u32;

--- a/physx/src/cooking.rs
+++ b/physx/src/cooking.rs
@@ -38,10 +38,14 @@ impl Cooking {
         unsafe { PxCooking_validateTriangleMesh(self.get_raw(), mesh_desc) }
     }
 
-    pub fn create_triangle_mesh(&self, mesh_desc: &PxTriangleMeshDesc) -> Result<Geometry, ()> {
+    pub fn create_triangle_mesh(
+        &self,
+        mesh_desc: &PxTriangleMeshDesc,
+        mesh_scale: Vec3,
+    ) -> Result<Geometry, ()> {
         let mut cooking_result = PxTriangleMeshCookingResult::eSUCCESS;
         unsafe {
-            if self.validate_triangle_mesh(mesh_desc) {
+            if !self.validate_triangle_mesh(mesh_desc) {
                 Err(())
             } else {
                 let insertion_callback =
@@ -54,7 +58,6 @@ impl Cooking {
                     &mut cooking_result,
                 );
 
-                let mesh_scale = Vec3::new(XZ_SCALE, HEIGHT_SCALE, XZ_SCALE);
                 let mesh_scale = PxMeshScale_new_2(&gl_to_px_v3(mesh_scale));
 
                 Ok(Geometry::TriangleMesh(PxTriangleMeshGeometry_new_1(
@@ -97,7 +100,7 @@ impl Cooking {
         }
     }
 
-    pub fn make_geometry(&mut self, desc: ColliderDesc) -> PhysicsGeometry {
+    pub fn make_geometry(&mut self, desc: ColliderDesc, mesh_scale: Vec3) -> PhysicsGeometry {
         let geometry: Geometry = unsafe {
             match desc {
                 ColliderDesc::Sphere(radius) => Geometry::Sphere(PxSphereGeometry_new_1(radius)),
@@ -119,7 +122,7 @@ impl Cooking {
                     mesh_desc.triangles.stride = (3 * std::mem::size_of::<u32>()) as u32;
                     mesh_desc.triangles.data = indices.as_ptr() as *const std::ffi::c_void;
 
-                    self.create_triangle_mesh(&mesh_desc)
+                    self.create_triangle_mesh(&mesh_desc, mesh_scale)
                         .expect("failed creating triangle mesh")
                 }
             }

--- a/physx/src/geometry.rs
+++ b/physx/src/geometry.rs
@@ -11,6 +11,7 @@
 
 /* Stolen from world/physics.rs */
 
+use glam::Vec3;
 use physx_sys::*;
 
 pub type Point3 = PxVec3;
@@ -72,6 +73,7 @@ pub enum ColliderDesc {
     TriMesh {
         vertices: Vec<Point3>,
         indices: Vec<u32>,
+        mesh_scale: Vec3,
     },
 }
 

--- a/physx/src/geometry.rs
+++ b/physx/src/geometry.rs
@@ -13,8 +13,7 @@
 
 use physx_sys::*;
 
-use glam::Vec3;
-pub type Point3 = Vec3;
+pub type Point3 = PxVec3;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(i32)]
@@ -63,7 +62,7 @@ impl Into<PxGeometryType::Enum> for GeometryType {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub enum ColliderDesc {
     Sphere(f32),
     Box(f32, f32, f32),


### PR DESCRIPTION
* Using PxVec3 in triangle meshes, so the sizes match up
  Previously this used glam's Vec3, which does not always match the size of Physx's PxVec3. 

* Added mesh scale as an argument to `create_triange_mesh`

* Fixed validation being checked backwards

