### PR TITLE
Release physx 0.5.0 and physx-sys 0.3.0

### DIFF
--- a/physx-sys/Cargo.toml
+++ b/physx-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "physx-sys"
 description = "Unsafe bindings for NVIDIA PhysX C++ SDK"
-version = "0.2.4+4.1.1"
+version = "0.3.0"
 authors = ["Embark <opensource@embark-studios.com>", "Tomasz Stachowiak <h3@h3.gd>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/EmbarkStudios/physx-rs"

--- a/physx/Cargo.toml
+++ b/physx/Cargo.toml
@@ -15,7 +15,7 @@ doctest = false
 
 [dependencies]
 physx-macros = { version = "0.1", path = "../physx-macros" }
-physx-sys = { version = "0.2", path = "../physx-sys" }
+physx-sys = { version = "^0.3", path = "../physx-sys" }
 
 enumflags2 = "0.6"
 log = "0.4"

--- a/physx/Cargo.toml
+++ b/physx/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "physx"
 description = "High-level Rust interface for Nvidia PhysX"
-version = "0.4.2"
+version = "0.5.0"
 authors = ["Embark <opensource@embark-studios.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/EmbarkStudios/physx-rs"


### PR DESCRIPTION
Should we squash?

Had to make the last commit myself.