### PR TITLE
(cargo-release) version 0.5.1

### DIFF
--- a/physx/Cargo.toml
+++ b/physx/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "physx"
 description = "High-level Rust interface for Nvidia PhysX"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Embark <opensource@embark-studios.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/EmbarkStudios/physx-rs"


### PR DESCRIPTION
There was a flag --no-dev-version to cargo release to avoid that awkward version bump.