### PR TITLE
Only bring in cmake crate if `use-cmake` is enabled

### DIFF
--- a/physx-sys/Cargo.toml
+++ b/physx-sys/Cargo.toml
@@ -35,8 +35,8 @@ doctest = false
 
 [build-dependencies]
 cc = { version = "1.0", features = ["parallel"] }
-cmake = "0.1.35"
+cmake = { version = "0.1.35", optional = true }
 
 [features]
 structgen = []
-use-cmake = []
+use-cmake = ["cmake"]

--- a/physx-sys/build.rs
+++ b/physx-sys/build.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::{env, path::PathBuf};
 
 struct Environment {
@@ -17,7 +19,9 @@ struct Context {
     includes: Vec<PathBuf>,
 }
 
+#[cfg(not(feature = "use-cmake"))]
 include!("cc.rs");
+#[cfg(feature = "use-cmake")]
 include!("cmake.rs");
 
 fn main() {
@@ -34,7 +38,6 @@ fn main() {
         _ => "profile",
     };
 
-    let use_cmake = env::var("CARGO_FEATURE_USE_CMAKE").is_ok();
     let target = env::var("TARGET").expect("TARGET not specified");
     let host = env::var("HOST").expect("HOST not specified");
 
@@ -71,11 +74,11 @@ fn main() {
             static_crt,
         };
 
-        if use_cmake {
-            cmake_compile(environment);
-        } else {
-            cc_compile(environment)
-        }
+        #[cfg(feature = "use-cmake")]
+        cmake_compile(environment);
+
+        #[cfg(not(feature = "use-cmake"))]
+        cc_compile(environment);
     }
 
     let mut cc_builder = cc::Build::new();
@@ -173,7 +176,7 @@ fn main() {
     println!("cargo:rerun-if-changed=PhysX/physx/include/PxPhysicsVersion.h");
 
     // Remove PxConfig.h since we're only allowed to modify OUT_DIR.
-    if use_cmake {
+    if cfg!(feature = "use-cmake") {
         let _ = std::fs::remove_file(
             env::current_dir()
                 .unwrap()


### PR DESCRIPTION
Nice to not bring in the `cmake` crate at all by default! 

You're welcome @Jake-Shadle :)