### PR TITLE
Release physx 0.6.0 and physx-sys 0.4.0

### DIFF
--- a/physx-sys/CHANGELOG.md
+++ b/physx-sys/CHANGELOG.md
@@ -1,7 +1,12 @@
 ## [Unreleased]
 
-## [0.3.0] - 2020-03-04
+## [0.4.0] - 2020-05-07
+### Changed
+- [PR#59](https://github.com/EmbarkStudios/physx-rs/pull/59) made `cmake` into an optional, non-default, dependency for building the C++ code, in favor of just using the `cc` crate. CMake can be enabled via the `use-cmake` feature.
+- [PR#59](https://github.com/EmbarkStudios/physx-rs/pull/59) updated the fork of the PhysX repository to include various changes to the C++ code to allow it to be cross-compiled for Windows via clang from Linux or Mac.
+- [PR#59](https://github.com/EmbarkStudios/physx-rs/pull/59) added a `structgen` feature flag, to make the creation of the C++ executable that generates the Rust bindings for the C++ code optional, as the generated code is now checked in and should only need to be updated when PhysX itself is updated.
 
+## [0.3.0] - 2020-03-04
 ### Added
 - Ability to not run the default filter shader before the callback.
 

--- a/physx-sys/Cargo.toml
+++ b/physx-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "physx-sys"
 description = "Unsafe bindings for NVIDIA PhysX C++ SDK"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Embark <opensource@embark-studios.com>", "Tomasz Stachowiak <h3@h3.gd>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/EmbarkStudios/physx-rs"

--- a/physx/CHANGELOG.md
+++ b/physx/CHANGELOG.md
@@ -1,19 +1,19 @@
 ## [Unreleased]
 
-## [0.5.1] - 2020-03-04
-
+## [0.6.0] - 2020-05-07
 ### Changed
+- [PR#59](https://github.com/EmbarkStudios/physx-rs/pull/59) made `cmake` into an optional, non-default, dependency for building the C++ code, in favor of just using the `cc` crate. CMake can be enabled via the `use-cmake` feature.
+- [PR#59](https://github.com/EmbarkStudios/physx-rs/pull/59) added a `structgen` feature flag, to make the creation of the C++ executable that generates the Rust bindings for the C++ code optional, as the generated code is now checked in and should only need to be updated when PhysX itself is updated.
 
+## [0.5.1] - 2020-03-04
+### Changed
 - Restored a way to create a PxScene without a Scene wrapper.
 
 ## [0.5.0] - 2020-03-04
-
 ### Added
-
 - Character controller wrapper, character manager available via Scene.
 
 ### Changed
-
 - Ability to not run the default filter shader before the callback.
 - Fix for triangle mesh data when using glam with SSE enabled
 

--- a/physx/Cargo.toml
+++ b/physx/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "physx"
 description = "High-level Rust interface for Nvidia PhysX"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Embark <opensource@embark-studios.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/EmbarkStudios/physx-rs"
@@ -15,7 +15,7 @@ doctest = false
 
 [dependencies]
 physx-macros = { version = "0.1", path = "../physx-macros" }
-physx-sys = { version = "^0.3", path = "../physx-sys" }
+physx-sys = { version = "^0.4", path = "../physx-sys" }
 
 enumflags2 = "0.6"
 log = "0.4"


### PR DESCRIPTION
Biggest thing this includes is #59 and #60.

Made this not a patch version release, as although those changes are compatible they are fairly major in the build system so better for users to choose to upgrade to them manually with a version change.