### PR TITLE
Fix clang 10.0.0 warnings

### DIFF
--- a/physx-sys/cc.rs
+++ b/physx-sys/cc.rs
@@ -287,6 +287,8 @@ fn add_common(ctx: &mut Context) {
             "-Werror",
             "-Wstrict-aliasing=2",
             "-Weverything",
+            "-Wno-alloca",
+            "-Wno-anon-enum-enum-conversion",
             "-Wno-documentation-deprecated-sync",
             "-Wno-documentation-unknown-command",
             "-Wno-gnu-anonymous-struct",


### PR DESCRIPTION
* Uses new commits on upstream physx code to fix a few warnings
* Disables some warnings that are just tedious to fix in C++ code