### PR TITLE
Add the ability to register a raycast filter callback from Rust

### DIFF
--- a/physx-sys/src/lib.rs
+++ b/physx-sys/src/lib.rs
@@ -126,7 +126,7 @@
 //! Unless you explicitly state otherwise, any contribution intentionally
 //! submitted for inclusion in the work by you, as defined in the Apache-2.0
 //! license, shall be dual licensed as above, without any additional terms or
-//! conditions.  
+//! conditions.
 
 #[cfg(feature = "structgen")]
 include!(concat!(env!("OUT_DIR"), "/structgen_out.rs"));
@@ -171,6 +171,12 @@ pub const fn version(major: u32, minor: u32, patch: u32) -> u32 {
 pub type CollisionCallback =
     unsafe extern "C" fn(*mut c_void, *const PxContactPairHeader, *const PxContactPair, count: u32);
 
+/// return 0 = eNONE
+/// return 1 = eTOUCH
+/// return 2 = eBLOCK
+pub type RaycastHitCallback =
+    unsafe extern "C" fn(*const PxFilterData, *const PxActor, *const c_void) -> i32;
+
 #[repr(C)]
 pub struct FilterShaderCallbackInfo {
     pub attributes0: u32,
@@ -189,8 +195,16 @@ extern "C" {
     pub fn physx_create_physics(foundation: *mut PxFoundation) -> *mut PxPhysics;
     pub fn get_default_allocator() -> *mut PxDefaultAllocator;
     pub fn get_default_error_callback() -> *mut PxDefaultErrorCallback;
+
+    /// Destroy the returned callback object using PxQueryFilterCallback_delete.
     pub fn create_raycast_filter_callback(
         actor_to_ignore: *const PxRigidActor,
+    ) -> *mut PxQueryFilterCallback;
+
+    /// Destroy the returned callback object using PxQueryFilterCallback_delete.
+    pub fn create_raycast_filter_callback_func(
+        callback: RaycastHitCallback,
+        userdata: *mut c_void,
     ) -> *mut PxQueryFilterCallback;
 
     pub fn get_default_simulation_filter_shader() -> *mut c_void;

--- a/physx-sys/src/lib.rs
+++ b/physx-sys/src/lib.rs
@@ -171,16 +171,16 @@ pub const fn version(major: u32, minor: u32, patch: u32) -> u32 {
 pub type CollisionCallback =
     unsafe extern "C" fn(*mut c_void, *const PxContactPairHeader, *const PxContactPair, count: u32);
 
-/// return 0 = eNONE
-/// return 1 = eTOUCH
-/// return 2 = eBLOCK
+/// return 0 = PxQueryHitType::eNONE
+/// return 1 = PxQueryHitType::eTOUCH
+/// return 2 = PxQueryHitType::eBLOCK
 pub type RaycastHitCallback = unsafe extern "C" fn(
     *const PxRigidActor,
     *const PxFilterData,
     *const PxShape,
     hit_flags: u32,
     *const c_void,
-) -> i32;
+) -> u32;
 
 #[repr(C)]
 pub struct FilterShaderCallbackInfo {

--- a/physx-sys/src/lib.rs
+++ b/physx-sys/src/lib.rs
@@ -174,8 +174,13 @@ pub type CollisionCallback =
 /// return 0 = eNONE
 /// return 1 = eTOUCH
 /// return 2 = eBLOCK
-pub type RaycastHitCallback =
-    unsafe extern "C" fn(*const PxRigidActor, *const PxFilterData, *const PxShape, hit_flags: u32, *const c_void) -> i32;
+pub type RaycastHitCallback = unsafe extern "C" fn(
+    *const PxRigidActor,
+    *const PxFilterData,
+    *const PxShape,
+    hit_flags: u32,
+    *const c_void,
+) -> i32;
 
 #[repr(C)]
 pub struct FilterShaderCallbackInfo {

--- a/physx-sys/src/lib.rs
+++ b/physx-sys/src/lib.rs
@@ -175,7 +175,7 @@ pub type CollisionCallback =
 /// return 1 = eTOUCH
 /// return 2 = eBLOCK
 pub type RaycastHitCallback =
-    unsafe extern "C" fn(*const PxFilterData, *const PxActor, *const c_void) -> i32;
+    unsafe extern "C" fn(*const PxRigidActor, *const PxFilterData, *const PxShape, hit_flags: u32, *const c_void) -> i32;
 
 #[repr(C)]
 pub struct FilterShaderCallbackInfo {

--- a/physx-sys/src/physx_api.cpp
+++ b/physx-sys/src/physx_api.cpp
@@ -118,7 +118,7 @@ class RaycastFilterCallback : public PxQueryFilterCallback
     }
 };
 
-typedef int (*RaycastHitCallback)(const PxRigidActor *actor, PxFilterData const *filterData, const void *userData);
+typedef int (*RaycastHitCallback)(const PxRigidActor *actor, const PxFilterData *filterData, const PxShape *shape, uint32_t hitFlags, const void *userData);
 
 class RaycastFilterTrampoline : public PxQueryFilterCallback
 {
@@ -129,12 +129,13 @@ class RaycastFilterTrampoline : public PxQueryFilterCallback
     RaycastHitCallback mCallback;
     const void *mUserData;
 
-    virtual PxQueryHitType::Enum preFilter(const PxFilterData &filterData, const PxShape *shape, const PxRigidActor *actor, PxHitFlags &)
+    virtual PxQueryHitType::Enum preFilter(const PxFilterData &filterData, const PxShape *shape, const PxRigidActor *actor, PxHitFlags &hitFlags)
     {
-        switch (mCallback(actor, &filterData, mUserData)) {
+        switch (mCallback(actor, &filterData, shape, (uint32_t)hitFlags, mUserData)) {
         case 0: return PxQueryHitType::eNONE;
         case 1: return PxQueryHitType::eTOUCH;
         case 2: return PxQueryHitType::eBLOCK;
+        default: return PxQueryHitType::eNONE;
         }
     }
 

--- a/physx-sys/src/physx_api.cpp
+++ b/physx-sys/src/physx_api.cpp
@@ -118,7 +118,7 @@ class RaycastFilterCallback : public PxQueryFilterCallback
     }
 };
 
-typedef int (*RaycastHitCallback)(const PxRigidActor *actor, const PxFilterData *filterData, const PxShape *shape, uint32_t hitFlags, const void *userData);
+typedef uint32_t (*RaycastHitCallback)(const PxRigidActor *actor, const PxFilterData *filterData, const PxShape *shape, uint32_t hitFlags, const void *userData);
 
 class RaycastFilterTrampoline : public PxQueryFilterCallback
 {


### PR DESCRIPTION
With this, you can register a callback to use to decide what objects can be hit by raycasts. In the callback, you get the actor, the custom filterdata for the mesh, and a userdata pointer. To reject a single object for example, pass in the PxActor through userdata and compare.