### PR TITLE
New interface for registering simulation event callbacks

### DIFF
--- a/physx-sys/CHANGELOG.md
+++ b/physx-sys/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- [PR#80](https://github.com/EmbarkStudios/physx-rs/pull/80) New way to register simulation event callbacks, supporting all callback types this time.
+
 ## [0.4.8] - 2020-07-02
 
 ### Fixed

--- a/physx-sys/Cargo.toml
+++ b/physx-sys/Cargo.toml
@@ -37,7 +37,7 @@ doctest = false
 
 [build-dependencies]
 cc = { version = "1.0", features = ["parallel"] }
-cmake = { version = "0.1.35", optional = true }
+cmake = { version = "0.1.44", optional = true }
 
 [features]
 structgen = []

--- a/physx-sys/src/lib.rs
+++ b/physx-sys/src/lib.rs
@@ -268,10 +268,10 @@ extern "C" {
     pub fn destroy_contact_callback(callback: *mut PxSimulationEventCallback);
 
     /// New interface to handle simulation events, replacing create_contact_callback.
-    pub fn create_simulation_event_handler(
+    pub fn create_simulation_event_callbacks(
         callbacks: *const SimulationEventCallbackInfo,
     ) -> *mut PxSimulationEventCallback;
-    pub fn destroy_simulation_event_handler(callback: *mut PxSimulationEventCallback);
+    pub fn destroy_simulation_event_callbacks(callback: *mut PxSimulationEventCallback);
 
     /// Override the default filter shader in the scene with a custom function.
     /// If call_default_filter_shader_first is set to true, this will first call the

--- a/physx-sys/src/physx_api.cpp
+++ b/physx-sys/src/physx_api.cpp
@@ -213,30 +213,13 @@ extern "C"
         return (void *)PxDefaultSimulationFilterShader;
     }
 
-    // DEPRECATED
-    PxSimulationEventCallback *create_contact_callback(CollisionCallback callback, void *userData)
-    {
-        SimulationEventCallbackInfo callbacks{};
-        callbacks.collisionCallback = callback;
-        callbacks.collisionUserData = userData;
-        SimulationEventTrampoline *trampoline = new SimulationEventTrampoline(&callbacks);
-        return static_cast<PxSimulationEventCallback *>(trampoline);
-    }
-
-    // DEPRECATED
-    void destroy_contact_callback(PxSimulationEventCallback *callback)
-    {
-        SimulationEventTrampoline *trampoline = static_cast<SimulationEventTrampoline *>(callback);
-        delete trampoline;
-    }
-
-    PxSimulationEventCallback *create_simulation_event_handler(const SimulationEventCallbackInfo *callbacks)
+    PxSimulationEventCallback *create_simulation_event_callbacks(const SimulationEventCallbackInfo *callbacks)
     {
         SimulationEventTrampoline *trampoline = new SimulationEventTrampoline(callbacks);
         return static_cast<PxSimulationEventCallback *>(trampoline);
     }
 
-    void destroy_simulation_event_handler(PxSimulationEventCallback *callback)
+    void destroy_simulation_event_callbacks(PxSimulationEventCallback *callback)
     {
         SimulationEventTrampoline *trampoline = static_cast<SimulationEventTrampoline *>(callback);
         delete trampoline;

--- a/physx/CHANGELOG.md
+++ b/physx/CHANGELOG.md
@@ -4,9 +4,13 @@
 
 ## [Unreleased]
 
-### Changed
+### Added
+
+- [PR#80](https://github.com/EmbarkStudios/physx-rs/pull/80) New way to register simulation event callbacks, supporting all callback types this time.
 
 ## [0.7.0] - 2020-06-29
+
+### Changed
 
 - [PR#72](https://github.com/EmbarkStudios/physx-rs/pull/72) Upgrade `glam` to 0.9. This includes a change of `Vec3` internal representation from 16-byte SIMD type to 12-byte 3x floats.
 

--- a/physx/src/physics.rs
+++ b/physx/src/physics.rs
@@ -226,7 +226,12 @@ impl Physics {
         let scene = scene_builder.build(self);
         let mut scene = Box::new(scene);
         let scene_ptr = scene.as_mut() as *mut Scene;
-        scene.set_simulation_event_callback(on_contact_callback, scene_ptr);
+        let callback_info = SimulationEventCallbackInfo {
+            collision_callback: Some(on_contact_callback),
+            collision_user_data: scene_ptr as *mut std::os::raw::c_void,
+            ..Default::default()
+        };
+        scene.set_simulation_event_callbacks(&callback_info);
         scene
     }
 

--- a/physx/src/scene.rs
+++ b/physx/src/scene.rs
@@ -37,7 +37,6 @@ pub struct Scene {
     bodies: Vec<ArticulationReducedCoordinate>,
     statics: Vec<RigidStatic>,
     dynamics: Vec<RigidDynamic>,
-    old_simulation_callback: Option<*mut PxSimulationEventCallback>,
     simulation_callback: Option<*mut PxSimulationEventCallback>,
     controller_manager: Option<ControllerManager>,
 }
@@ -51,7 +50,6 @@ impl Scene {
             bodies: Vec::new(),
             dynamics: Vec::new(),
             statics: Vec::new(),
-            old_simulation_callback: None,
             simulation_callback: None,
             controller_manager: None,
         };
@@ -73,11 +71,8 @@ impl Scene {
         self.dynamics.drain(..).for_each(|mut e| e.release());
 
         // destroy simulation callback if we have one
-        if let Some(callback) = self.old_simulation_callback.take() {
-            destroy_contact_callback(callback);
-        }
         if let Some(callback) = self.simulation_callback.take() {
-            destroy_simulation_event_handler(callback);
+            destroy_simulation_event_callbacks(callback);
         }
 
         if let Some(manager) = self.controller_manager.take() {
@@ -298,9 +293,13 @@ impl Scene {
         userdata: *mut T,
     ) {
         unsafe {
-            let callback =
-                physx_sys::create_contact_callback(callback, userdata as *mut std::ffi::c_void);
-            self.old_simulation_callback = Some(callback);
+            let callback_info = physx_sys::SimulationEventCallbackInfo {
+                collision_callback: Some(callback),
+                collision_user_data: userdata as *mut std::ffi::c_void,
+                ..Default::default()
+            };
+            let callback = physx_sys::create_simulation_event_callbacks(&callback_info);
+            self.simulation_callback = Some(callback);
             PxScene_setSimulationEventCallback_mut(
                 self.px_scene
                     .write()
@@ -316,7 +315,7 @@ impl Scene {
         callbacks: &physx_sys::SimulationEventCallbackInfo,
     ) {
         unsafe {
-            let callback = physx_sys::create_simulation_event_handler(&*callbacks);
+            let callback = physx_sys::create_simulation_event_callbacks(&*callbacks);
             self.simulation_callback = Some(callback);
             PxScene_setSimulationEventCallback_mut(
                 self.px_scene


### PR DESCRIPTION
Now supporting registering all six types, not just collision. Needed for trigger shapes.

Preserves, and deprecates, the old interface.