### PR TITLE
Disable the Android structgen CI target

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -210,7 +210,7 @@ jobs:
           AR_aarch64_linux_android: ${{env.ANDROID_NDK_ROOT }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ar
         uses: actions-rs/cargo@v1
         with:
-          command: build 
+          command: build
           args: --target aarch64-linux-android
 
   build_android_release:
@@ -236,38 +236,38 @@ jobs:
           AR_aarch64_linux_android: ${{env.ANDROID_NDK_ROOT }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ar
         uses: actions-rs/cargo@v1
         with:
-          command: build 
+          command: build
           args: --target aarch64-linux-android --release
 
-  android_structgen:
-    name: Structgen (aarch64-linux-android)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - run: git submodule update --init
-      - run: rustup target add aarch64-linux-android
-      - run: sudo apt-get install libclang-9-dev
-      - name: build & run pxbind
-        env:
-          LD_aarch64_linux_android: ${{env.ANDROID_NDK_ROOT }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ld
-          CC_aarch64_linux_android: ${{env.ANDROID_NDK_ROOT }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android29-clang
-          CXX_aarch64_linux_android: ${{env.ANDROID_NDK_ROOT }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android29-clang++
-          AR_aarch64_linux_android: ${{env.ANDROID_NDK_ROOT }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ar
-        run: export CC=/usr/bin/clang && export CXX=/usr/bin/clang++ && cd physx-sys/pxbind && ./build.sh && echo build succeeded && ./run_android.sh
-      - name: Upload
-        shell: bash
-        run: |
-          # Copy the structgen output to a deterministic location
-          rs=$(find physx-sys/src/ -name physx_generated.rs)
-          hpp=$(find physx-sys/src/ -name physx_generated.hpp)
-          mkdir ./structgen
-          cp $rs ./structgen/structgen.rs
-          cp $hpp ./structgen/structgen_out.hpp
-      - uses: actions/upload-artifact@v1
-        with:
-          name: structgen-aarch64-linux-android
-          path: structgen
+#  android_structgen:
+#    name: Structgen (aarch64-linux-android)
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v1
+#      - uses: actions-rs/toolchain@v1
+#        with:
+#          toolchain: stable
+#          override: true
+#      - run: git submodule update --init
+#      - run: rustup target add aarch64-linux-android
+#      - run: sudo apt-get install libclang-9-dev
+#      - name: build & run pxbind
+#        env:
+#          LD_aarch64_linux_android: ${{env.ANDROID_NDK_ROOT }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ld
+#          CC_aarch64_linux_android: ${{env.ANDROID_NDK_ROOT }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android29-clang
+#          CXX_aarch64_linux_android: ${{env.ANDROID_NDK_ROOT }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android29-clang++
+#          AR_aarch64_linux_android: ${{env.ANDROID_NDK_ROOT }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ar
+#        run: export CC=/usr/bin/clang && export CXX=/usr/bin/clang++ && cd physx-sys/pxbind && ./build.sh && echo build succeeded && ./run_android.sh
+#      - name: Upload
+#        shell: bash
+#        run: |
+#          # Copy the structgen output to a deterministic location
+#          rs=$(find physx-sys/src/ -name physx_generated.rs)
+#          hpp=$(find physx-sys/src/ -name physx_generated.hpp)
+#          mkdir ./structgen
+#          cp $rs ./structgen/structgen.rs
+#          cp $hpp ./structgen/structgen_out.hpp
+#      - uses: actions/upload-artifact@v1
+#        with:
+#          name: structgen-aarch64-linux-android
+#          path: structgen


### PR DESCRIPTION
It's currently broken in the "build and run pxbind" step with the following output:

```
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/clang++
-- Check for working CXX compiler: /usr/bin/clang++ - works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found LLVM 6.0.0
-- Using LLVMConfig.cmake in: /usr/lib/llvm-6.0/cmake
-- LLVM_LIBS: LLVMX86AsmParser;LLVMBitReader;LLVMSupport;LLVMMC;LLVMOption;LLVMProfileData
bash: llvm-config: command not found
-- Configuring done
-- Generating done
-- Build files have been written to: /home/runner/work/physx-rs/physx-rs/physx-sys/pxbind/build
Scanning dependencies of target pxbind
[ 50%] Building CXX object CMakeFiles/pxbind.dir/main.cpp.o
/home/runner/work/physx-rs/physx-rs/physx-sys/pxbind/main.cpp:1:10: fatal error: 'clang/AST/AST.h' file not found
#include "clang/AST/AST.h"
         ^~~~~~~~~~~~~~~~~
1 error generated.
make[2]: *** [CMakeFiles/pxbind.dir/main.cpp.o] Error 1
CMakeFiles/pxbind.dir/build.make:79: recipe for target 'CMakeFiles/pxbind.dir/main.cpp.o' failed
CMakeFiles/Makefile2:120: recipe for target 'CMakeFiles/pxbind.dir/all' failed
make[1]: *** [CMakeFiles/pxbind.dir/all] Error 2
make: *** [all] Error 2
Makefile:146: recipe for target 'all' failed
```

See issue #68 .