### PR TITLE
Release physx 0.7.1 and physx-sys 0.4.9

### DIFF
--- a/physx-sys/CHANGELOG.md
+++ b/physx-sys/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased]
 
+## [0.4.9] - 2020-08-13
+
 ### Added
 
 - [PR#80](https://github.com/EmbarkStudios/physx-rs/pull/80) New way to register simulation event callbacks, supporting all callback types this time.
@@ -69,7 +71,8 @@
 
 - Ability to not run the default filter shader before the callback.
 
-[Unreleased]: https://github.com/EmbarkStudios/physx-rs/compare/physx-sys-v0.4.8...HEAD
+[Unreleased]: https://github.com/EmbarkStudios/physx-rs/compare/physx-sys-v0.4.9...HEAD
+[0.4.9]: https://github.com/EmbarkStudios/physx-rs/compare/physx-sys-v0.4.8...physx-sys-v0.4.9
 [0.4.8]: https://github.com/EmbarkStudios/physx-rs/compare/physx-sys-v0.4.7...physx-sys-v0.4.8
 [0.4.7]: https://github.com/EmbarkStudios/physx-rs/compare/physx-sys-v0.4.6...physx-sys-v0.4.7
 [0.4.6]: https://github.com/EmbarkStudios/physx-rs/compare/physx-sys-v0.4.4...physx-sys-v0.4.6

--- a/physx-sys/Cargo.toml
+++ b/physx-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "physx-sys"
 description = "Unsafe bindings for NVIDIA PhysX C++ SDK"
-version = "0.4.8"
+version = "0.4.9"
 authors = ["Embark <opensource@embark-studios.com>", "Tomasz Stachowiak <h3@h3.gd>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/EmbarkStudios/physx-rs"

--- a/physx/CHANGELOG.md
+++ b/physx/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Added
 
-- [PR#80](https://github.com/EmbarkStudios/physx-rs/pull/80) New way to register simulation event callbacks, supporting all callback types this time.
+- [PR#80](https://github.com/EmbarkStudios/physx-rs/pull/80) New way to register simulation event callbacks, supporting all callback types this time. Deprecates `set_simulation_event_callback` in favor of `set_simulation_event_callbacks`.
 
 ## [0.7.0] - 2020-06-29
 

--- a/physx/CHANGELOG.md
+++ b/physx/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased]
 
+## [0.7.1] - 2020-08-13
+
 ### Added
 
 - [PR#80](https://github.com/EmbarkStudios/physx-rs/pull/80) New way to register simulation event callbacks, supporting all callback types this time.
@@ -44,7 +46,8 @@
 - Ability to not run the default filter shader before the callback.
 - Fix for triangle mesh data when using glam with SSE enabled
 
-[Unreleased]: https://github.com/EmbarkStudios/physx-rs/compare/physx-v0.7.0...HEAD
+[Unreleased]: https://github.com/EmbarkStudios/physx-rs/compare/physx-v0.7.1...HEAD
+[0.7.1]: https://github.com/EmbarkStudios/physx-rs/compare/physx-v0.7.0...physx-v0.7.1
 [0.7.0]: https://github.com/EmbarkStudios/physx-rs/compare/physx-v0.6.1...physx-v0.7.0
 [0.6.1]: https://github.com/EmbarkStudios/physx-rs/compare/physx-v0.6.0...physx-v0.6.1
 [0.6.0]: https://github.com/EmbarkStudios/physx-rs/compare/physx-v0.5.1...physx-v0.6.0

--- a/physx/Cargo.toml
+++ b/physx/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "physx"
 description = "High-level Rust interface for Nvidia PhysX"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Embark <opensource@embark-studios.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/EmbarkStudios/physx-rs"
@@ -15,7 +15,7 @@ doctest = false
 
 [dependencies]
 physx-macros = { version = "0.1", path = "../physx-macros" }
-physx-sys = { version = "^0.4", path = "../physx-sys" }
+physx-sys = { version = "0.4.9", path = "../physx-sys" }
 
 enumflags2 = "0.6"
 log = "0.4"


### PR DESCRIPTION
@hrydgard looks like you deprecated `set_simulation_event_callback` also in #80, can you add that to the CHANGELOG also. I guess technically we should do a minor release rather than a patch release if it has deprecations, but think this is fine as we are pre 1.0 