### PR TITLE
Allow setting the solver type when creating a scene

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
     name: Test (Debug)
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-2019, macOS-latest]
+        os: [ubuntu-latest, macOS-latest]
     env:
       DEVELOPER_DIR: /Applications/Xcode_11.1.app
     runs-on: ${{ matrix.os }}
@@ -87,7 +87,7 @@ jobs:
     name: Test (Release)
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-2019, macOS-latest]
+        os: [ubuntu-latest, macOS-latest]
     env:
       DEVELOPER_DIR: /Applications/Xcode_11.1.app
     runs-on: ${{ matrix.os }}

--- a/physx-sys/CHANGELOG.md
+++ b/physx-sys/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- [PR#87](https://github.com/EmbarkStudios/physx-rs/pull/87) Allow setting the solver type when creating a scene
+
 ## [0.4.9] - 2020-08-13
 
 ### Added

--- a/physx/src/actor.rs
+++ b/physx/src/actor.rs
@@ -3,7 +3,6 @@
 // Created: 16 April 2019
 
 #![warn(clippy::all)]
-#![warn(rust_2018_idioms)]
 
 /*!
 Trait for PxActor

--- a/physx/src/articulation_base.rs
+++ b/physx/src/articulation_base.rs
@@ -3,7 +3,6 @@
 // Created: 15 April 2019
 
 #![warn(clippy::all)]
-#![warn(rust_2018_idioms)]
 
 /*!
 Wrapper for PxArticulationBase

--- a/physx/src/articulation_cache.rs
+++ b/physx/src/articulation_cache.rs
@@ -3,7 +3,6 @@
 // Created: 16 April 2019
 
 #![warn(clippy::all)]
-#![warn(rust_2018_idioms)]
 
 /*!
 

--- a/physx/src/articulation_joint.rs
+++ b/physx/src/articulation_joint.rs
@@ -3,7 +3,6 @@
 // Created: 16 April 2019
 
 #![warn(clippy::all)]
-#![warn(rust_2018_idioms)]
 
 /*!
 

--- a/physx/src/articulation_joint_base.rs
+++ b/physx/src/articulation_joint_base.rs
@@ -3,7 +3,6 @@
 // Created: 16 April 2019
 
 #![warn(clippy::all)]
-#![warn(rust_2018_idioms)]
 
 /*!
 

--- a/physx/src/articulation_joint_reduced_coordinate.rs
+++ b/physx/src/articulation_joint_reduced_coordinate.rs
@@ -3,7 +3,6 @@
 // Created:  2 April 2019
 
 #![warn(clippy::all)]
-#![warn(rust_2018_idioms)]
 
 /*!
 

--- a/physx/src/articulation_link.rs
+++ b/physx/src/articulation_link.rs
@@ -3,7 +3,6 @@
 // Created:  2 April 2019
 
 #![warn(clippy::all)]
-#![warn(rust_2018_idioms)]
 
 /*!
 A link of a reduced coordinate multibody.

--- a/physx/src/articulation_reduced_coordinate.rs
+++ b/physx/src/articulation_reduced_coordinate.rs
@@ -3,7 +3,6 @@
 // Created: 10 April 2019
 
 #![warn(clippy::all)]
-#![warn(rust_2018_idioms)]
 
 /*!
 ArticulationReducedCoordinate wrapper for PhysX.

--- a/physx/src/body.rs
+++ b/physx/src/body.rs
@@ -3,7 +3,6 @@
 // Created: 10 April 2019
 
 #![warn(clippy::all)]
-#![warn(rust_2018_idioms)]
 
 /*!
 Utility for handle-based usage

--- a/physx/src/controller.rs
+++ b/physx/src/controller.rs
@@ -1,5 +1,4 @@
 #![warn(clippy::all)]
-#![warn(rust_2018_idioms)]
 
 use crate::px_type::*;
 use crate::rigid_dynamic::RigidDynamic;

--- a/physx/src/controller.rs
+++ b/physx/src/controller.rs
@@ -31,7 +31,7 @@ impl ControllerManager {
         Controller::new(controller)
     }
 
-    pub unsafe fn release(self: Self) {
+    pub unsafe fn release(self) {
         PxControllerManager_release_mut(self.ptr);
     }
 }
@@ -64,7 +64,7 @@ impl CapsuleControllerDesc {
         }
     }
 
-    pub fn release(self: Self) {
+    pub fn release(self) {
         unsafe { PxCapsuleControllerDesc_delete(self.ptr) };
     }
 }

--- a/physx/src/cooking.rs
+++ b/physx/src/cooking.rs
@@ -3,7 +3,6 @@
 // Created: 12 April 2019
 
 #![warn(clippy::all)]
-#![warn(rust_2018_idioms)]
 
 /*!
 

--- a/physx/src/foundation.rs
+++ b/physx/src/foundation.rs
@@ -3,7 +3,6 @@
 // Created: 10 April 2019
 
 #![warn(clippy::all)]
-#![warn(rust_2018_idioms)]
 
 /*!
 Wrapper for PxFoundation class

--- a/physx/src/geometry.rs
+++ b/physx/src/geometry.rs
@@ -3,7 +3,6 @@
 // Created:  2 April 2019
 
 #![warn(clippy::all)]
-#![warn(rust_2018_idioms)]
 
 /*!
 

--- a/physx/src/heightfield.rs
+++ b/physx/src/heightfield.rs
@@ -3,7 +3,6 @@
 // Created: 11 April 2019
 
 #![warn(clippy::all)]
-#![warn(rust_2018_idioms)]
 
 /*!
 

--- a/physx/src/lib.rs
+++ b/physx/src/lib.rs
@@ -4,6 +4,7 @@
 
 #![warn(clippy::all)]
 #![warn(rust_2018_idioms)]
+#![allow(unused_attributes)]
 
 //! # 🎳 physx
 //!

--- a/physx/src/lib.rs
+++ b/physx/src/lib.rs
@@ -4,7 +4,6 @@
 
 #![warn(clippy::all)]
 #![warn(rust_2018_idioms)]
-#![allow(unused_attributes)]
 
 //! # 🎳 physx
 //!

--- a/physx/src/math/mod.rs
+++ b/physx/src/math/mod.rs
@@ -3,7 +3,6 @@
 // Created: 17 June 2019
 
 #![warn(clippy::all)]
-#![warn(rust_2018_idioms)]
 
 /*!
 

--- a/physx/src/prelude.rs
+++ b/physx/src/prelude.rs
@@ -3,7 +3,6 @@
 // Created:  9 May 2019
 
 #![warn(clippy::all)]
-#![warn(rust_2018_idioms)]
 
 /*!
 Prelude for commonly useful types

--- a/physx/src/px_type.rs
+++ b/physx/src/px_type.rs
@@ -3,7 +3,6 @@
 // Created: 12 June 2019
 
 #![warn(clippy::all)]
-#![warn(rust_2018_idioms)]
 
 /*!
 

--- a/physx/src/rigid_actor.rs
+++ b/physx/src/rigid_actor.rs
@@ -3,7 +3,6 @@
 // Created: 15 April 2019
 
 #![warn(clippy::all)]
-#![warn(rust_2018_idioms)]
 
 /*!
 Trait for RigidActor

--- a/physx/src/rigid_body.rs
+++ b/physx/src/rigid_body.rs
@@ -3,7 +3,6 @@
 // Created: 17 April 2019
 
 #![warn(clippy::all)]
-#![warn(rust_2018_idioms)]
 
 /*!
 

--- a/physx/src/rigid_dynamic.rs
+++ b/physx/src/rigid_dynamic.rs
@@ -3,7 +3,6 @@
 // Created: 19 June 2019
 
 #![warn(clippy::all)]
-#![warn(rust_2018_idioms)]
 
 /*!
 Wrapper implementation for PxRigidDynamic

--- a/physx/src/rigid_static.rs
+++ b/physx/src/rigid_static.rs
@@ -3,7 +3,6 @@
 // Created: 15 April 2019
 
 #![warn(clippy::all)]
-#![warn(rust_2018_idioms)]
 
 /*!
 

--- a/physx/src/scene.rs
+++ b/physx/src/scene.rs
@@ -3,7 +3,6 @@
 // Created: 10 April 2019
 
 #![warn(clippy::all)]
-#![warn(rust_2018_idioms)]
 #![allow(clippy::missing_safety_doc)]
 #![allow(deprecated)]
 
@@ -648,7 +647,7 @@ impl SceneBuilder {
 
     /// Set solver type
     ///
-    /// Default: eTGS
+    /// Default: PGS
     pub fn set_solver_type(&mut self, solver_type: SolverType) -> &mut Self {
         self.solver_type = solver_type;
         self

--- a/physx/src/shape.rs
+++ b/physx/src/shape.rs
@@ -3,7 +3,6 @@
 // Created: 29 April 2019
 
 #![warn(clippy::all)]
-#![warn(rust_2018_idioms)]
 
 /*!
 Wrapper for PxShape

--- a/physx/src/traits/collidable.rs
+++ b/physx/src/traits/collidable.rs
@@ -3,7 +3,6 @@
 // Created: 12 June 2019
 
 #![warn(clippy::all)]
-#![warn(rust_2018_idioms)]
 
 /*!
 

--- a/physx/src/traits/get_raw.rs
+++ b/physx/src/traits/get_raw.rs
@@ -3,7 +3,6 @@
 // Created: 15 April 2019
 
 #![warn(clippy::all)]
-#![warn(rust_2018_idioms)]
 
 /*!
 Utility trait for dealing with wrapped inheritance

--- a/physx/src/traits/mod.rs
+++ b/physx/src/traits/mod.rs
@@ -3,7 +3,6 @@
 // Created: 12 June 2019
 
 #![warn(clippy::all)]
-#![warn(rust_2018_idioms)]
 
 /*!
 

--- a/physx/src/traits/releasable.rs
+++ b/physx/src/traits/releasable.rs
@@ -3,7 +3,6 @@
 // Created: 12 June 2019
 
 #![warn(clippy::all)]
-#![warn(rust_2018_idioms)]
 
 /*!
 Release trait to make sure our Deref hack calls the right Release

--- a/physx/src/traits/to_flags.rs
+++ b/physx/src/traits/to_flags.rs
@@ -3,7 +3,6 @@
 // Created: 16 April 2019
 
 #![warn(clippy::all)]
-#![warn(rust_2018_idioms)]
 
 /*!
 Extension trait for Into to use for local enums

--- a/physx/src/transform.rs
+++ b/physx/src/transform.rs
@@ -3,7 +3,6 @@
 // Created:  2 April 2019
 
 #![warn(clippy::all)]
-#![warn(rust_2018_idioms)]
 
 /*!
 This defines utility conversion functions from PhysX data types to glm datatypes

--- a/physx/src/user_data.rs
+++ b/physx/src/user_data.rs
@@ -3,7 +3,6 @@
 // Created: 12 June 2019
 
 #![warn(clippy::all)]
-#![warn(rust_2018_idioms)]
 
 /*!
 

--- a/physx/src/visual_debugger.rs
+++ b/physx/src/visual_debugger.rs
@@ -3,7 +3,6 @@
 // Created:  5 April 2019
 
 #![warn(clippy::all)]
-#![warn(rust_2018_idioms)]
 
 /*!
 


### PR DESCRIPTION
Also makes the broadphasetype setting work, it never did anything.

Additionally, disables a meta-warning that has appeared in newer Rust compilers:

```
warning: warn(rust_2018_idioms) is ignored unless specified at crate level
 --> C:\embark\physx-rs\physx\src\px_type.rs:6:9
  |
6 | #![warn(rust_2018_idioms)]
  |         ^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_attributes)]` on by default
```