### PR TITLE
Allow overriding the PxAllocatorCallback with a pair of custom callback functions

### DIFF
--- a/physx-sys/README.md
+++ b/physx-sys/README.md
@@ -101,4 +101,4 @@ Note that the [PhysX C++ SDK](https://github.com/NVIDIAGameWorks/PhysX) has it's
 Unless you explicitly state otherwise, any contribution intentionally
 submitted for inclusion in the work by you, as defined in the Apache-2.0
 license, shall be dual licensed as above, without any additional terms or
-conditions.  
+conditions.

--- a/physx-sys/src/lib.rs
+++ b/physx-sys/src/lib.rs
@@ -243,9 +243,18 @@ pub struct FilterShaderCallbackInfo {
 
 pub type SimulationFilterShader = unsafe extern "C" fn(*mut FilterShaderCallbackInfo) -> u16;
 
+pub type AllocCallback =
+    unsafe extern "C" fn(u64, *const c_void, *const c_void, u32, *const c_void) -> *mut c_void;
+
+pub type DeallocCallback = unsafe extern "C" fn(*const c_void, *const c_void);
+
 extern "C" {
     pub fn physx_create_foundation() -> *mut PxFoundation;
+    pub fn physx_create_foundation_with_alloc(
+        allocator: *mut PxDefaultAllocator,
+    ) -> *mut PxFoundation;
     pub fn physx_create_physics(foundation: *mut PxFoundation) -> *mut PxPhysics;
+
     pub fn get_default_allocator() -> *mut PxDefaultAllocator;
     pub fn get_default_error_callback() -> *mut PxDefaultErrorCallback;
 
@@ -259,6 +268,12 @@ extern "C" {
         callback: RaycastHitCallback,
         userdata: *mut c_void,
     ) -> *mut PxQueryFilterCallback;
+
+    pub fn create_alloc_callback(
+        alloc_callback: AllocCallback,
+        dealloc_callback: DeallocCallback,
+        userdata: *mut c_void,
+    ) -> *mut PxAllocatorCallback;
 
     pub fn get_default_simulation_filter_shader() -> *mut c_void;
 

--- a/physx/src/foundation.rs
+++ b/physx/src/foundation.rs
@@ -40,6 +40,17 @@ impl Foundation {
         Self::from_ptr(px_foundation)
     }
 
+    pub fn new_with_alloc(version: u32, allocator: *mut PxAllocatorCallback) -> Self {
+        let px_foundation = unsafe {
+            phys_PxCreateFoundation(
+                version,
+                allocator,
+                get_default_error_callback() as *mut PxErrorCallback,
+            )
+        };
+        Self::from_ptr(px_foundation)
+    }
+
     pub fn get_error_callback(&mut self) -> *mut PxErrorCallback {
         unsafe { PxFoundation_getErrorCallback_mut(self.get_raw_mut()) }
     }


### PR DESCRIPTION
This lets the user handle or track allocations as they please.