### PR TITLE
Release physx 0.7.4 and physx-sys 0.4.10

### DIFF
--- a/physx-sys/CHANGELOG.md
+++ b/physx-sys/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## [Unreleased]
 
+## [0.4.10] - 2020-10-20
+
+### Added
+
+- [PR#94](https://github.com/EmbarkStudios/physx-rs/pull/94) Allow overriding the PxAllocatorCallback with a pair of custom callback functions
+
 ## [0.4.9] - 2020-08-13
 
 ### Added
@@ -71,7 +77,8 @@
 
 - Ability to not run the default filter shader before the callback.
 
-[Unreleased]: https://github.com/EmbarkStudios/physx-rs/compare/physx-sys-v0.4.9...HEAD
+[Unreleased]: https://github.com/EmbarkStudios/physx-rs/compare/physx-sys-v0.4.10...HEAD
+[0.4.10]: https://github.com/EmbarkStudios/physx-rs/compare/physx-sys-v0.4.9...physx-sys-v0.4.10
 [0.4.9]: https://github.com/EmbarkStudios/physx-rs/compare/physx-sys-v0.4.8...physx-sys-v0.4.9
 [0.4.8]: https://github.com/EmbarkStudios/physx-rs/compare/physx-sys-v0.4.7...physx-sys-v0.4.8
 [0.4.7]: https://github.com/EmbarkStudios/physx-rs/compare/physx-sys-v0.4.6...physx-sys-v0.4.7

--- a/physx-sys/Cargo.toml
+++ b/physx-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "physx-sys"
 description = "Unsafe bindings for NVIDIA PhysX C++ SDK"
-version = "0.4.9"
+version = "0.4.10"
 authors = ["Embark <opensource@embark-studios.com>", "Tomasz Stachowiak <h3@h3.gd>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/EmbarkStudios/physx-rs"
@@ -9,7 +9,7 @@ edition = "2018"
 build = "build.rs"
 readme = "README.md"
 keywords = ["physics"]
-categories = ["external-ffi-bindings", "simulation", "game-engines"] 
+categories = ["external-ffi-bindings", "simulation", "game-engines"]
 exclude = [
     "PhysX/**/*.bat",
     "PhysX/**/*.html",

--- a/physx/CHANGELOG.md
+++ b/physx/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## [Unreleased]
 
+## [0.7.4] - 2020-10-20
+
+### Added
+
+- [PR#94](https://github.com/EmbarkStudios/physx-rs/pull/94) Allow overriding the PxAllocatorCallback with a pair of custom callback functions
+
 ## [0.7.3] - 2020-10-14
 
 ### Added
@@ -58,7 +64,8 @@
 - Ability to not run the default filter shader before the callback.
 - Fix for triangle mesh data when using glam with SSE enabled
 
-[Unreleased]: https://github.com/EmbarkStudios/physx-rs/compare/physx-v0.7.3...HEAD
+[Unreleased]: https://github.com/EmbarkStudios/physx-rs/compare/physx-v0.7.4...HEAD
+[0.7.4]: https://github.com/EmbarkStudios/physx-rs/compare/physx-v0.7.3...physx-v0.7.4
 [0.7.3]: https://github.com/EmbarkStudios/physx-rs/compare/physx-v0.7.2...physx-v0.7.3
 [0.7.2]: https://github.com/EmbarkStudios/physx-rs/compare/physx-v0.7.1...physx-v0.7.2
 [0.7.1]: https://github.com/EmbarkStudios/physx-rs/compare/physx-v0.7.0...physx-v0.7.1

--- a/physx/Cargo.toml
+++ b/physx/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "physx"
 description = "High-level Rust interface for Nvidia PhysX"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["Embark <opensource@embark-studios.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/EmbarkStudios/physx-rs"
@@ -15,7 +15,7 @@ doctest = false
 
 [dependencies]
 physx-macros = { version = "0.1", path = "../physx-macros" }
-physx-sys = { version = "0.4.9", path = "../physx-sys" }
+physx-sys = { version = "0.4.10", path = "../physx-sys" }
 
 enumflags2 = "0.6"
 log = "0.4"


### PR DESCRIPTION
As it says on the tin.

Adds the ability to override the memory allocator.