### PR TITLE
Add deps.rs and Ark Discord badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ![Build Status](https://github.com/EmbarkStudios/physx-rs/workflows/CI/badge.svg)
 [![Contributor Covenant](https://img.shields.io/badge/contributor%20covenant-v1.4%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
+[![dependency status](https://deps.rs/repo/github/EmbarkStudios/physx-rs/status.svg)](https://deps.rs/repo/github/EmbarkStudios/physx-rs)
 [![Embark](https://img.shields.io/badge/embark-open%20source-blueviolet.svg)](http://embark.games)
+[![Embark](https://img.shields.io/badge/discord-ark-%237289da.svg?logo=discord)](https://discord.gg/dAuKfZS)
 
 Rust binding and wrapper over [NVIDIA PhysX](https://github.com/NVIDIAGameWorks/PhysX), a popular and mature physics engine particularly well-suited for games.
 

--- a/physx-macros/README.md
+++ b/physx-macros/README.md
@@ -5,6 +5,7 @@
 [![Docs](https://docs.rs/physx/badge.svg)](https://docs.rs/physx)
 [![Contributor Covenant](https://img.shields.io/badge/contributor%20covenant-v1.4%20adopted-ff69b4.svg)](../CODE_OF_CONDUCT.md)
 [![Embark](https://img.shields.io/badge/embark-open%20source-blueviolet.svg)](http://embark.games)
+[![Embark](https://img.shields.io/badge/discord-ark-%237289da.svg?logo=discord)](https://discord.gg/dAuKfZS)
 
 Utility macros used internally by the [`physx`](https://crates.io/crates/physx) crate.
 

--- a/physx-sys/README.md
+++ b/physx-sys/README.md
@@ -5,6 +5,7 @@
 [![Docs](https://docs.rs/physx-sys/badge.svg)](https://docs.rs/physx-sys)
 [![Contributor Covenant](https://img.shields.io/badge/contributor%20covenant-v1.4%20adopted-ff69b4.svg)](../CODE_OF_CONDUCT.md)
 [![Embark](https://img.shields.io/badge/embark-open%20source-blueviolet.svg)](http://embark.games)
+[![Embark](https://img.shields.io/badge/discord-ark-%237289da.svg?logo=discord)](https://discord.gg/dAuKfZS)
 
 Unsafe automatically-generated Rust bindings for [NVIDIA PhysX 4.1](https://github.com/NVIDIAGameWorks/PhysX) C++ API.
 

--- a/physx/README.md
+++ b/physx/README.md
@@ -5,6 +5,7 @@
 [![Docs](https://docs.rs/physx/badge.svg)](https://docs.rs/physx)
 [![Contributor Covenant](https://img.shields.io/badge/contributor%20covenant-v1.4%20adopted-ff69b4.svg)](../CODE_OF_CONDUCT.md)
 [![Embark](https://img.shields.io/badge/embark-open%20source-blueviolet.svg)](http://embark.games)
+[![Embark](https://img.shields.io/badge/discord-ark-%237289da.svg?logo=discord)](https://discord.gg/dAuKfZS)
 
 [**This is a work in progress** 🚧](https://github.com/EmbarkStudios/physx-rs/issues/3)
 


### PR DESCRIPTION
Looks quite nice and likely should have both on all of our Rust crates.

https://deps.rs recently got revived and has new mantainers, and our Ark Discord is pretty new also