### PR TITLE
Use Xcode 11.7 on Mac CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 on: [push, pull_request]
 name: CI
 env:
-    ANDROID_NDK_ROOT : /usr/local/lib/android/sdk/ndk-bundle
+  ANDROID_NDK_ROOT: /usr/local/lib/android/sdk/ndk-bundle
 jobs:
   lint:
     name: Lint
@@ -89,7 +89,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest]
     env:
-      DEVELOPER_DIR: /Applications/Xcode_11.1.app
+      DEVELOPER_DIR: /Applications/Xcode_11.7.app
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v1
@@ -238,7 +238,6 @@ jobs:
         with:
           command: build
           args: --target aarch64-linux-android --release
-
 #  android_structgen:
 #    name: Structgen (aarch64-linux-android)
 #    runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest]
     env:
-      DEVELOPER_DIR: /Applications/Xcode_11.1.app
+      DEVELOPER_DIR: /Applications/Xcode_11.7.app
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v1
@@ -139,7 +139,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-2019, macOS-latest]
     env:
-      DEVELOPER_DIR: /Applications/Xcode_11.1.app
+      DEVELOPER_DIR: /Applications/Xcode_11.7.app
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v1
@@ -159,7 +159,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-2019, macOS-latest]
     env:
-      DEVELOPER_DIR: /Applications/Xcode_11.1.app
+      DEVELOPER_DIR: /Applications/Xcode_11.7.app
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
First tried Xcode 12 but got build errors, so switched to latest Xcode 11.7 for now instead