### PR TITLE
Fix warnings found by clippy

### DIFF
--- a/physx-sys/cc.rs
+++ b/physx-sys/cc.rs
@@ -239,11 +239,12 @@ fn add_common(ctx: &mut Context) {
         let ndk_path = PathBuf::from(
             env::var("ANDROID_NDK_ROOT").expect("environment variable \"ANDROID_NDK_ROOT\" has not been set"),
         );
-        let ndk_toolchain = match ccenv.host.as_str() {
+        let host_str = ccenv.host.as_str();
+        let ndk_toolchain = match host_str {
             "x86_64-pc-windows-msvc" => "windows-x86_64",
             "x86_64-unknown-linux-gnu" => "linux-x86_64",
             "x86_64-apple-darwin" => "darwin-x86_64",
-            _ => panic!("Host triple {} is unsupported for cross-compilation to Android"),
+            _ => panic!("Host triple {} is unsupported for cross-compilation to Android", host_str),
         };
         let sysroot_path = ndk_path
             .join("toolchains/llvm/prebuilt")

--- a/physx/src/controller.rs
+++ b/physx/src/controller.rs
@@ -98,9 +98,9 @@ impl Controller {
 
 fn to_extended(vec: &Vec3) -> PxExtendedVec3 {
     PxExtendedVec3 {
-        x: vec.x() as f64,
-        y: vec.y() as f64,
-        z: vec.z() as f64,
+        x: vec.x as f64,
+        y: vec.y as f64,
+        z: vec.z as f64,
     }
 }
 

--- a/physx/src/math/mod.rs
+++ b/physx/src/math/mod.rs
@@ -33,17 +33,17 @@ pub struct Isometry {
 impl Isometry {
     /// Extracts the rotation and translation matrix from a matrix.
     pub fn from_mat4(m: &Mat4) -> Self {
-        let x = m.x_axis();
-        let y = m.y_axis();
-        let z = m.z_axis();
+        let x = m.x_axis;
+        let y = m.y_axis;
+        let z = m.z_axis;
         assert!(
             x.is_normalized() && y.is_normalized() && z.is_normalized(),
             "All axis have to be of length 1"
         );
-        assert!(x.w() == 0.0 && y.w() == 0.0 && z.w() == 0.0, "Unable to extract the rotation matrix because one of the W components of the axis wasn't 0.0");
+        assert!(x.w == 0.0 && y.w == 0.0 && z.w == 0.0, "Unable to extract the rotation matrix because one of the W components of the axis wasn't 0.0");
 
         let rotation = Mat4::from_cols(x, y, z, Vec4::unit_w());
-        let translation = Mat4::from_translation(m.w_axis().truncate());
+        let translation = Mat4::from_translation(m.w_axis.truncate());
         Self {
             rotation,
             translation,

--- a/physx/src/physics.rs
+++ b/physx/src/physics.rs
@@ -205,7 +205,7 @@ impl Physics {
         offset: f32,
         material: *mut PxMaterial,
     ) -> RigidStatic {
-        let plane = PxPlane_new_1(normal.x(), normal.y(), normal.z(), offset);
+        let plane = PxPlane_new_1(normal.x, normal.y, normal.z, offset);
         RigidStatic::new(phys_PxCreatePlane(self.get_raw_mut(), &plane, material))
     }
 

--- a/physx/src/transform.rs
+++ b/physx/src/transform.rs
@@ -47,7 +47,7 @@ pub fn gl_to_px_tf(trans: Mat4) -> PxTransform {
 /// Convert a reference to a Mat4 to a PxTransform
 pub fn gl_to_px_tf_ref(trans: &Mat4) -> PxTransform {
     let quat: PxQuatWrap = Quat::from_rotation_mat4(&trans).into();
-    let (x, y, z, _) = trans.w_axis().into();
+    let (x, y, z, _) = trans.w_axis.into();
     unsafe { PxTransform_new_4(x, y, z, quat.0) }
 }
 


### PR DESCRIPTION
One error is caused by a missing argument to panic!.
The others seem to be related to the recent glam upgrade.