### PR TITLE
Fix issues I ran into when porting our code to the new API

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Rust binding and wrapper over [NVIDIA PhysX](https://github.com/NVIDIAGameWorks/
 
 Created and maintained by [Embark](http://embark.games) and _**not**_ officially supported by NVIDIA.
 
-This repository contains 3 crates:
+This repository contains 2 crates:
 
 | Name | Description | Links |
 | --- | --- | --- |
 | [`physx`](physx/) | High-level interface on top of `physx-sys` 🚧 | [![Crates.io](https://img.shields.io/crates/v/physx.svg)](https://crates.io/crates/physx) [![Docs](https://docs.rs/physx/badge.svg)](https://docs.rs/physx) |
 | [`physx-sys`](physx-sys/) | Unsafe bindings to the [PhysX C++ API](https://github.com/NVIDIAGameWorks/PhysX) | [![Crates.io](https://img.shields.io/crates/v/physx-sys.svg)](https://crates.io/crates/physx-sys) [![Docs](https://docs.rs/physx-sys/badge.svg)](https://docs.rs/physx-sys) |
-| [`physx-macros`](physx-macros/) | Utility macros used internally by the `physx` crate | [![Crates.io](https://img.shields.io/crates/v/physx-macros.svg)](https://crates.io/crates/physx-macros) [![Docs](https://docs.rs/physx-macros/badge.svg)](https://docs.rs/physx-macros) |
+
 
 ## Why use it?
 
@@ -33,7 +33,9 @@ This repository contains 3 crates:
 
 ### Alternatives
 
-* [nphysics](https://github.com/rustsim/nphysics): a 2- and 3-dimensional physics engine for games and animations written in Rust. It is a good option for projects which do not require the full feature set of PhysX or prefer a native Rust solution.
+* [Rapier](https://github.com/dimforge/rapier): a 2D and 3D physics engine for games, animation, and robotics written in Rust.  Fully cross-platform, with web support and optional cross-platform determinism on IEEE 754-2008 compliant systems.
+
+* [nphysics](https://github.com/dimforge/nphysics): a 2- and 3-dimensional physics engine for games and animations written in Rust. It is a good option for projects which do not require the full feature set of PhysX or prefer a native Rust solution.
 
 ## Presentation
 
@@ -49,14 +51,13 @@ The following code example shows how [`physx`](physx/) can be initialized.
 const PX_PHYSICS_VERSION: u32 = physx::version(4, 1, 1);
 let mut foundation = Foundation::new(PX_PHYSICS_VERSION);
 
-let mut physics = PhysicsBuilder::default()
-    .load_extensions(false) // switch this flag to load extensions during setup
-    .build(&mut foundation);
+let mut physics = PhysicsFoundation::default();
 
-let mut scene = physics.create_scene(
-    SceneBuilder::default()
-        .set_gravity(glm::vec3(0.0, -9.81, 0.0))
-        .set_simulation_threading(SimulationThreadType::Dedicated(1)),
+let mut scene = physics.create(
+    SceneDescriptor {
+        gravity: PxVec3::new(0.0, 0.0, -9.81),
+        ..SceneDescriptor::new(MySceneUserData::default())
+    }
 );
 
 ```

--- a/physx/CHANGELOG.md
+++ b/physx/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ## [Unreleased]
 
+- [PR#113](https://github.com/EmbarkStudios/physx-rs/pull/98) Fix various issues
+  found using physx-rs in practice after the big PR#98 merge from 0.9.0.
+  You now create a scene using `Physics::create()` with a new scene descriptor
+  that can represent all the parameters of PxSceneDesc.
+
 ## [0.9.0] - 2020-12-03
 
 ### Refactored

--- a/physx/examples/ball_physx.rs
+++ b/physx/examples/ball_physx.rs
@@ -98,11 +98,7 @@ fn main() {
 
     // Setup the scene object.  The PxScene type alias makes this much cleaner.
     // There are lots of unwrap calls due to potential null pointers.
-    let mut scene: Owner<PxScene> = physics
-        .create_scene(
-            scene_desc,
-        )
-        .unwrap();
+    let mut scene: Owner<PxScene> = physics.create_scene(scene_desc).unwrap();
 
     let mut material = physics.create_material(0.5, 0.5, 0.6, ()).unwrap();
 

--- a/physx/examples/ball_physx.rs
+++ b/physx/examples/ball_physx.rs
@@ -2,6 +2,7 @@
 // Copyright © 2019, Embark Studios, all rights reserved.
 // Created:  3 July 2019
 
+use enumflags2::BitFlags;
 use physx::prelude::*;
 
 /// This is a WIP example for how the rustified wrappers lets your reduced the
@@ -82,20 +83,24 @@ fn main() {
     // The default allocator is the one provided by PhysX.
     let mut physics_foundation = PhysicsFoundation::<_, PxShape>::default();
 
-    let physics = physics_foundation.physics();
+    let physics = physics_foundation.physics_mut();
+
+    let scene_desc = PxSceneDesc::new(
+        physics,
+        (),
+        PxSimulationEventCallback::new(None, None, None, None, Some(OnAdvance)).unwrap(),
+        FilterShaderDescriptor::Default,
+        1,
+        SolverType::PGS,
+        BitFlags::<SceneFlag>::empty(),
+    )
+    .unwrap();
 
     // Setup the scene object.  The PxScene type alias makes this much cleaner.
     // There are lots of unwrap calls due to potential null pointers.
     let mut scene: Owner<PxScene> = physics
         .create_scene(
-            PxSceneDesc::new(
-                physics,
-                (),
-                PxSimulationEventCallback::new(None, None, None, None, Some(OnAdvance)).unwrap(),
-                FilterShaderDescriptor::Default,
-                1,
-            )
-            .unwrap(),
+            scene_desc,
         )
         .unwrap();
 

--- a/physx/examples/ball_physx.rs
+++ b/physx/examples/ball_physx.rs
@@ -80,9 +80,7 @@ fn main() {
     // Holds a PxFoundation and a PxPhysics.
     // Also has an optional Pvd and transport, not enabled by default.
     // The default allocator is the one provided by PhysX.
-    let mut physics_foundation = PhysicsFoundation::<_, PxShape>::default();
-
-    let physics = physics_foundation.physics_mut();
+    let mut physics = PhysicsFoundation::<_, PxShape>::default();
 
     // Setup the scene object.  The PxScene type alias makes this much cleaner.
     // There are lots of unwrap calls due to potential null pointers.

--- a/physx/examples/ball_physx.rs
+++ b/physx/examples/ball_physx.rs
@@ -2,7 +2,6 @@
 // Copyright © 2019, Embark Studios, all rights reserved.
 // Created:  3 July 2019
 
-use enumflags2::BitFlags;
 use physx::prelude::*;
 
 /// This is a WIP example for how the rustified wrappers lets your reduced the
@@ -85,20 +84,15 @@ fn main() {
 
     let physics = physics_foundation.physics_mut();
 
-    let scene_desc = PxSceneDesc::new(
-        physics,
-        (),
-        PxSimulationEventCallback::new(None, None, None, None, Some(OnAdvance)).unwrap(),
-        FilterShaderDescriptor::Default,
-        1,
-        SolverType::PGS,
-        BitFlags::<SceneFlag>::empty(),
-    )
-    .unwrap();
-
     // Setup the scene object.  The PxScene type alias makes this much cleaner.
     // There are lots of unwrap calls due to potential null pointers.
-    let mut scene: Owner<PxScene> = physics.create_scene(scene_desc).unwrap();
+    let mut scene: Owner<PxScene> = physics
+        .create(SceneDescriptor {
+            gravity: PxVec3::new(0.0, -9.81, 0.0),
+            on_advance: Some(OnAdvance),
+            ..SceneDescriptor::new(())
+        })
+        .unwrap();
 
     let mut material = physics.create_material(0.5, 0.5, 0.6, ()).unwrap();
 

--- a/physx/src/convex_mesh.rs
+++ b/physx/src/convex_mesh.rs
@@ -14,7 +14,7 @@ impl ConvexMesh {
     /// Owner's own the pointer they wrap, using the pointer after dropping the Owner,
     /// or creating multiple Owners from the same pointer will cause UB.  Use `into_ptr` to
     /// retrieve the pointer and consume the Owner without dropping the pointee.
-    pub(crate) unsafe fn from_raw(ptr: *mut physx_sys::PxConvexMesh) -> Option<Owner<ConvexMesh>> {
+    pub unsafe fn from_raw(ptr: *mut physx_sys::PxConvexMesh) -> Option<Owner<ConvexMesh>> {
         Owner::from_raw(ptr as *mut Self)
     }
 }

--- a/physx/src/math/mod.rs
+++ b/physx/src/math/mod.rs
@@ -66,6 +66,19 @@ pub struct PxBounds3 {
     obj: physx_sys::PxBounds3,
 }
 
+impl PxBounds3 {
+    /// Creates largest bounds that avoid floating point exceptions.
+    pub fn max_bounds_extents() -> Self {
+        unsafe {
+            physx_sys::PxBounds3_new_1(
+                &physx_sys::PxVec3_new_2(-f32::MAX / 4.0),
+                &physx_sys::PxVec3_new_2(f32::MAX / 4.0),
+            )
+            .into()
+        }
+    }
+}
+
 crate::DeriveClassForNewType!(PxBounds3: PxBounds3);
 
 impl From<physx_sys::PxBounds3> for PxBounds3 {
@@ -77,5 +90,11 @@ impl From<physx_sys::PxBounds3> for PxBounds3 {
 impl Into<physx_sys::PxBounds3> for PxBounds3 {
     fn into(self) -> physx_sys::PxBounds3 {
         self.obj
+    }
+}
+
+impl Default for PxBounds3 {
+    fn default() -> Self {
+        Self::max_bounds_extents()
     }
 }

--- a/physx/src/physics.rs
+++ b/physx/src/physics.rs
@@ -105,6 +105,24 @@ pub struct PhysicsFoundation<Allocator: AllocatorCallback, Geom: Shape> {
     extensions_loaded: bool,
 }
 
+unsafe impl<T, Allocator: AllocatorCallback, Geom: Shape> Class<T>
+    for PhysicsFoundation<Allocator, Geom>
+where
+    physx_sys::PxPhysics: Class<T>,
+{
+    fn as_ptr(&self) -> *const T {
+        self.physics.obj.as_ptr()
+    }
+
+    fn as_mut_ptr(&mut self) -> *mut T {
+        self.physics.obj.as_mut_ptr()
+    }
+}
+
+impl<Allocator: AllocatorCallback, Geom: Shape> Physics for PhysicsFoundation<Allocator, Geom> {
+    type Shape = Geom;
+}
+
 impl<Allocator: AllocatorCallback, Geom: Shape> PhysicsFoundation<Allocator, Geom> {
     pub fn new(allocator: Allocator) -> PhysicsFoundation<Allocator, Geom> {
         let mut foundation =

--- a/physx/src/physics.rs
+++ b/physx/src/physics.rs
@@ -101,7 +101,7 @@ pub const PX_PHYSICS_VERSION: u32 = crate::version(4, 1, 1);
 pub struct PhysicsFoundation<Allocator: AllocatorCallback, Geom: Shape> {
     // Order matters here for Drop. Foundation must be dropped last.
     physics: Owner<PxPhysics<Geom>>,
-    pub pvd: Option<VisualDebugger>,
+    pvd: Option<VisualDebugger>,
     foundation: Owner<PxFoundation<Allocator>>,
     extensions_loaded: bool,
 }
@@ -128,12 +128,20 @@ impl<Allocator: AllocatorCallback, Geom: Shape> PhysicsFoundation<Allocator, Geo
         self.foundation.as_ref()
     }
 
+    pub fn pvd(&self) -> &Option<VisualDebugger> {
+        &self.pvd
+    }
+
     pub fn physics_mut(&mut self) -> &mut PxPhysics<Geom> {
         self.physics.as_mut()
     }
 
     pub fn foundation_mut(&mut self) -> &mut PxFoundation<Allocator> {
         self.foundation.as_mut()
+    }
+
+    pub fn pvd_mut(&mut self) -> &mut Option<VisualDebugger> {
+        &mut self.pvd
     }
 }
 

--- a/physx/src/physics.rs
+++ b/physx/src/physics.rs
@@ -145,8 +145,8 @@ impl<Allocator: AllocatorCallback, Geom: Shape> PhysicsFoundation<Allocator, Geo
         self.foundation.as_ref()
     }
 
-    pub fn pvd(&self) -> &Option<VisualDebugger> {
-        &self.pvd
+    pub fn pvd(&self) -> Option<&VisualDebugger> {
+        self.pvd.as_ref()
     }
 
     pub fn physics_mut(&mut self) -> &mut PxPhysics<Geom> {
@@ -157,8 +157,8 @@ impl<Allocator: AllocatorCallback, Geom: Shape> PhysicsFoundation<Allocator, Geo
         self.foundation.as_mut()
     }
 
-    pub fn pvd_mut(&mut self) -> &mut Option<VisualDebugger> {
-        &mut self.pvd
+    pub fn pvd_mut(&mut self) -> Option<&mut VisualDebugger> {
+        self.pvd.as_mut()
     }
 }
 

--- a/physx/src/physics.rs
+++ b/physx/src/physics.rs
@@ -100,9 +100,9 @@ pub const PX_PHYSICS_VERSION: u32 = crate::version(4, 1, 1);
 /// Parametrized by the Foundation's Allocator and the Physics' Shape type.
 pub struct PhysicsFoundation<Allocator: AllocatorCallback, Geom: Shape> {
     // Order matters here for Drop. Foundation must be dropped last.
-    pub physics: Owner<PxPhysics<Geom>>,
+    physics: Owner<PxPhysics<Geom>>,
     pub pvd: Option<VisualDebugger>,
-    pub foundation: Owner<PxFoundation<Allocator>>,
+    foundation: Owner<PxFoundation<Allocator>>,
     extensions_loaded: bool,
 }
 
@@ -120,8 +120,20 @@ impl<Allocator: AllocatorCallback, Geom: Shape> PhysicsFoundation<Allocator, Geo
         }
     }
 
-    pub fn physics(&mut self) -> &mut PxPhysics<Geom> {
+    pub fn physics(&self) -> &PxPhysics<Geom> {
+        self.physics.as_ref()
+    }
+
+    pub fn foundation(&self) -> &PxFoundation<Allocator> {
+        self.foundation.as_ref()
+    }
+
+    pub fn physics_mut(&mut self) -> &mut PxPhysics<Geom> {
         self.physics.as_mut()
+    }
+
+    pub fn foundation_mut(&mut self) -> &mut PxFoundation<Allocator> {
+        self.foundation.as_mut()
     }
 }
 
@@ -576,7 +588,7 @@ pub trait Physics: Class<physx_sys::PxPhysics> + Sized {
         unsafe { PxPhysics_getTolerancesScale(self.as_ptr()).as_ref() }
     }
 
-    /// Get the physiucs insertion callback, used for real-time cooking of physics meshes.
+    /// Get the physics insertion callback, used for real-time cooking of physics meshes.
     fn get_physics_insertion_callback(&mut self) -> Option<&mut PxPhysicsInsertionCallback> {
         unsafe { PxPhysics_getPhysicsInsertionCallback_mut(self.as_mut_ptr()).as_mut() }
     }

--- a/physx/src/prelude.rs
+++ b/physx/src/prelude.rs
@@ -36,11 +36,15 @@ pub use crate::rigid_body::{ForceMode, RigidBody, RigidBodyFlag, RigidBodyFlags}
 pub use crate::rigid_dynamic::{RigidDynamic, RigidDynamicLockFlag, RigidDynamicLockFlags};
 pub use crate::rigid_static::RigidStatic;
 pub use crate::scene::{
-    BroadPhaseType, FilterShaderDescriptor, PairFilteringMode, PruningStructureType, PxSceneDesc,
-    Scene, SceneFlag, SimulationThreadType, SolverType,
+    BroadPhaseType, FilterShaderDescriptor, PairFilteringMode, PruningStructureType, Scene,
+    SceneFlag, SimulationThreadType, SolverType,
 };
 pub use crate::shape::{CollisionLayer, Shape, ShapeFlag, ShapeFlags};
 pub use crate::simulation_event_callback::{
     AdvanceCallback, CollisionCallback, ConstraintBreakCallback, PxSimulationEventCallback,
     TriggerCallback, WakeSleepCallback,
+};
+pub use crate::traits::descriptor::{
+    ConstraintDescriptor, MaterialDescriptor, PlaneDescriptor, RigidDynamicDescriptor,
+    RigidStaticDescriptor, SceneDescriptor, ShapeDescriptor,
 };

--- a/physx/src/scene.rs
+++ b/physx/src/scene.rs
@@ -1041,7 +1041,7 @@ where
         simulation_filter_shader: FilterShaderDescriptor,
         thread_count: u32,
         solver_type: SolverType,
-        flags: BitFlags::<SceneFlag>,
+        flags: BitFlags<SceneFlag>,
     ) -> Option<Owner<PxSceneDesc<U, L, S, D, OC, OT, OCB, OWS, OA>>> {
         unsafe {
             let mut desc = PxSceneDesc_new(physics.get_tolerances_scale()?);

--- a/physx/src/scene.rs
+++ b/physx/src/scene.rs
@@ -36,7 +36,8 @@ use crate::{
     visual_debugger::PvdSceneClient,
 };
 
-use enumflags2::{self, *};
+use enumflags2::BitFlags;
+
 use std::{
     ffi::c_void,
     marker::PhantomData,
@@ -975,7 +976,7 @@ pub enum SimulationThreadType {
     Default,
 }
 
-#[derive(Copy, Clone, Debug, BitFlags)]
+#[derive(BitFlags, Copy, Clone, Debug)]
 #[repr(u32)]
 ///  eMUTABLE_FLAGS = eENABLE_ACTIVE_ACTORS|eEXCLUDE_KINEMATICS_FROM_ACTIVE_ACTORS
 pub enum SceneFlag {
@@ -1040,14 +1041,14 @@ where
         simulation_filter_shader: FilterShaderDescriptor,
         thread_count: u32,
         solver_type: SolverType,
-        flags: SceneFlag,
+        flags: BitFlags::<SceneFlag>,
     ) -> Option<Owner<PxSceneDesc<U, L, S, D, OC, OT, OCB, OWS, OA>>> {
         unsafe {
             let mut desc = PxSceneDesc_new(physics.get_tolerances_scale()?);
             desc.gravity = PxVec3::new(0.0, -9.81, 0.0).into();
             desc.cpuDispatcher =
                 phys_PxDefaultCpuDispatcherCreate(thread_count, null_mut()) as *mut _;
-            desc.flags.mBits = flags.into();
+            desc.flags.mBits = flags.bits();
             desc.solverType = match solver_type {
                 SolverType::PGS => PxSolverType::ePGS,
                 SolverType::TGS => PxSolverType::eTGS,

--- a/physx/src/scene.rs
+++ b/physx/src/scene.rs
@@ -4,7 +4,6 @@
 
 #![warn(clippy::all)]
 #![allow(clippy::missing_safety_doc)]
-#![allow(deprecated)]
 
 /*!
 Wrapper for PhysX PxScene
@@ -23,7 +22,6 @@ use crate::{
     foundation::ScratchBuffer,
     math::PxVec3,
     owner::Owner,
-    physics::Physics,
     pruning_structure::PruningStructure,
     rigid_actor::RigidActor,
     rigid_dynamic::RigidDynamic,
@@ -39,7 +37,6 @@ use crate::{
 use enumflags2::BitFlags;
 
 use std::{
-    ffi::c_void,
     marker::PhantomData,
     ptr::{drop_in_place, null, null_mut},
 };
@@ -47,9 +44,7 @@ use std::{
 // A glob import is super tempting, but the wrappers shadow the names of the physx_sys types,
 // so those types cannot be in scope.  Plus, it easier to see what's been implemented.
 use physx_sys::{
-    get_default_simulation_filter_shader,
     phys_PxCreateControllerManager,
-    phys_PxDefaultCpuDispatcherCreate,
     PxActorTypeFlags,
     PxBaseTask,
     PxBroadPhaseCallback,
@@ -65,11 +60,14 @@ use physx_sys::{
     */
     PxContactModifyCallback,
     PxCpuDispatcher,
+    PxFrictionType,
     PxPairFilteringMode,
     PxPruningStructureType,
-    PxSceneDesc_new,
     //PxHitFlags,
     PxSceneFlag,
+    PxSceneFlags,
+    PxSceneLimits,
+    PxSceneQueryUpdateMode,
     PxScene_addActor_mut,
     PxScene_addActors_mut,
     PxScene_addActors_mut_1,
@@ -867,6 +865,36 @@ impl HitFlag {
     }
 }
 
+#[derive(Debug, Copy, Clone)]
+#[repr(u32)]
+pub enum SceneQueryUpdateMode {
+    BuildEnabledCommitEnabled = 0,
+    BuildEnabledCommitDisabled = 1,
+    BuildDisabledCommitDisabled = 2,
+}
+
+impl Into<PxSceneQueryUpdateMode::Enum> for SceneQueryUpdateMode {
+    fn into(self) -> PxSceneQueryUpdateMode::Enum {
+        match self {
+            SceneQueryUpdateMode::BuildEnabledCommitEnabled => {
+                PxSceneQueryUpdateMode::eBUILD_ENABLED_COMMIT_ENABLED
+            }
+            SceneQueryUpdateMode::BuildEnabledCommitDisabled => {
+                PxSceneQueryUpdateMode::eBUILD_ENABLED_COMMIT_DISABLED
+            }
+            SceneQueryUpdateMode::BuildDisabledCommitDisabled => {
+                PxSceneQueryUpdateMode::eBUILD_DISABLED_COMMIT_DISABLED
+            }
+        }
+    }
+}
+
+impl Default for SceneQueryUpdateMode {
+    fn default() -> Self {
+        SceneQueryUpdateMode::BuildEnabledCommitEnabled
+    }
+}
+
 #[derive(Copy, Clone, Debug)]
 #[repr(u32)]
 pub enum PruningStructureType {
@@ -894,6 +922,12 @@ impl From<PxPruningStructureType::Enum> for PruningStructureType {
             PxPruningStructureType::eSTATIC_AABB_TREE => PruningStructureType::StaticAABBTree,
             _ => unimplemented!("Invalid enum variant."),
         }
+    }
+}
+
+impl Default for PruningStructureType {
+    fn default() -> Self {
+        PruningStructureType::DynamicAABBTree
     }
 }
 
@@ -934,31 +968,89 @@ impl From<PxPairFilteringMode::Enum> for PairFilteringMode {
     }
 }
 
-#[derive(Debug, Clone, Copy, BitFlags)]
-#[repr(u32)]
-pub enum BroadPhaseType {
-    SweepAndPrune = 1,
-    MultiBoxPruning = 2,
-    AutomaticBoxPruning = 4,
-    GPU = 8,
+#[derive(Default, Copy, Clone, Debug)]
+/// 0 means no limit.
+pub struct SceneLimits {
+    pub max_nb_actors: u32,
+    pub max_nb_bodies: u32,
+    pub max_nb_static_shapes: u32,
+    pub max_nb_dynamic_shapes: u32,
+    pub max_nb_aggregates: u32,
+    pub max_nb_constraints: u32,
+    pub max_nb_regions: u32,
+    pub max_nb_broad_phase_overlaps: u32,
 }
 
-impl Into<PxBroadPhaseType::Enum> for BroadPhaseType {
-    fn into(self) -> PxBroadPhaseType::Enum {
-        match self {
-            BroadPhaseType::SweepAndPrune => 0,
-            BroadPhaseType::MultiBoxPruning => 1,
-            BroadPhaseType::AutomaticBoxPruning => 2,
-            BroadPhaseType::GPU => 3,
+impl Into<PxSceneLimits> for SceneLimits {
+    fn into(self) -> PxSceneLimits {
+        PxSceneLimits {
+            maxNbActors: self.max_nb_actors,
+            maxNbBodies: self.max_nb_bodies,
+            maxNbStaticShapes: self.max_nb_static_shapes,
+            maxNbDynamicShapes: self.max_nb_dynamic_shapes,
+            maxNbAggregates: self.max_nb_aggregates,
+            maxNbConstraints: self.max_nb_constraints,
+            maxNbRegions: self.max_nb_regions,
+            maxNbBroadPhaseOverlaps: self.max_nb_broad_phase_overlaps,
         }
     }
 }
 
 #[derive(Debug, Clone, Copy)]
 #[repr(u32)]
+pub enum FrictionType {
+    Patch = 0,
+    OneDirectional = 1,
+    TwoDirectional = 2,
+}
+
+impl Into<PxFrictionType::Enum> for FrictionType {
+    fn into(self) -> PxFrictionType::Enum {
+        match self {
+            FrictionType::Patch => PxFrictionType::ePATCH,
+            FrictionType::OneDirectional => PxFrictionType::eONE_DIRECTIONAL,
+            FrictionType::TwoDirectional => PxFrictionType::eTWO_DIRECTIONAL,
+        }
+    }
+}
+
+impl Default for FrictionType {
+    fn default() -> Self {
+        FrictionType::Patch
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(u32)]
+pub enum BroadPhaseType {
+    SweepAndPrune = 0,
+    MultiBoxPruning = 1,
+    AutomaticBoxPruning = 2,
+    GPU = 3,
+}
+
+impl Into<PxBroadPhaseType::Enum> for BroadPhaseType {
+    fn into(self) -> PxBroadPhaseType::Enum {
+        match self {
+            BroadPhaseType::SweepAndPrune => PxBroadPhaseType::eSAP,
+            BroadPhaseType::MultiBoxPruning => PxBroadPhaseType::eMBP,
+            BroadPhaseType::AutomaticBoxPruning => PxBroadPhaseType::eABP,
+            BroadPhaseType::GPU => PxBroadPhaseType::eGPU,
+        }
+    }
+}
+
+impl Default for BroadPhaseType {
+    fn default() -> Self {
+        BroadPhaseType::AutomaticBoxPruning
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(u32)]
 pub enum SolverType {
-    PGS = 1,
-    TGS = 2,
+    PGS = 0,
+    TGS = 1,
 }
 
 impl Into<PxSolverType::Enum> for SolverType {
@@ -967,6 +1059,12 @@ impl Into<PxSolverType::Enum> for SolverType {
             SolverType::PGS => PxSolverType::ePGS,
             SolverType::TGS => PxSolverType::eTGS,
         }
+    }
+}
+
+impl Default for SolverType {
+    fn default() -> Self {
+        SolverType::PGS
     }
 }
 
@@ -1002,117 +1100,15 @@ impl Into<PxSceneFlag::Enum> for SceneFlag {
     }
 }
 
-/// A new typoe wrapper for PxSceneDesc.  Parametrized by it's user data type,
-/// the ArticulationLink, RigidStatic, and RigidDynamic actor types, and the
-/// Collision, Trigger, ConstraintBreak, WakeSleep, and Advance Callbacks.
-#[allow(clippy::type_complexity)]
-pub struct PxSceneDesc<U, L, S, D, OC, OT, OCB, OWS, OA>
-where
-    L: ArticulationLink,
-    S: RigidStatic,
-    D: RigidDynamic,
-    OC: CollisionCallback,
-    OT: TriggerCallback,
-    OCB: ConstraintBreakCallback,
-    OWS: WakeSleepCallback<L, S, D>,
-    OA: AdvanceCallback<L, D>,
-{
-    obj: physx_sys::PxSceneDesc,
-    phantom_user_data: PhantomData<(U, L, S, D, OC, OT, OCB, OWS, OA)>,
-}
+impl PxFlags for BitFlags<SceneFlag> {
+    type Target = PxSceneFlags;
 
-impl<U, L, S, D, OC, OT, OCB, OWS, OA> PxSceneDesc<U, L, S, D, OC, OT, OCB, OWS, OA>
-where
-    L: ArticulationLink,
-    S: RigidStatic,
-    D: RigidDynamic,
-    OC: CollisionCallback,
-    OT: TriggerCallback,
-    OCB: ConstraintBreakCallback,
-    OWS: WakeSleepCallback<L, S, D>,
-    OA: AdvanceCallback<L, D>,
-{
-    /// Create a new scene descriptor.
-    #[allow(clippy::type_complexity)]
-    pub fn new(
-        physics: &impl Physics,
-        user_data: U,
-        simulation_event_callback: Owner<PxSimulationEventCallback<L, S, D, OC, OT, OCB, OWS, OA>>,
-        simulation_filter_shader: FilterShaderDescriptor,
-        thread_count: u32,
-        solver_type: SolverType,
-        flags: BitFlags<SceneFlag>,
-    ) -> Option<Owner<PxSceneDesc<U, L, S, D, OC, OT, OCB, OWS, OA>>> {
-        unsafe {
-            let mut desc = PxSceneDesc_new(physics.get_tolerances_scale()?);
-            desc.gravity = PxVec3::new(0.0, -9.81, 0.0).into();
-            desc.cpuDispatcher =
-                phys_PxDefaultCpuDispatcherCreate(thread_count, null_mut()) as *mut _;
-            desc.flags.mBits = flags.bits();
-            desc.solverType = match solver_type {
-                SolverType::PGS => PxSolverType::ePGS,
-                SolverType::TGS => PxSolverType::eTGS,
-            };
-            match simulation_filter_shader {
-                FilterShaderDescriptor::Default => {
-                    desc.filterShader = get_default_simulation_filter_shader();
-                }
-                FilterShaderDescriptor::CallDefaultFirst(shader) => {
-                    physx_sys::enable_custom_filter_shader(&mut desc, shader, 1);
-                }
-                FilterShaderDescriptor::Custom(shader) => {
-                    physx_sys::enable_custom_filter_shader(&mut desc, shader, 0);
-                }
-            };
-            desc.simulationEventCallback = simulation_event_callback.into_ptr();
-            let desc = Box::into_raw(Box::new(desc)) as *mut Self;
-            (&mut *desc).init_user_data(user_data);
-            Owner::from_raw(desc)
-        }
-    }
-}
-
-unsafe impl<U, L, S, D, OA, OT, OWS, OC, OCB> UserData
-    for PxSceneDesc<U, L, S, D, OC, OT, OCB, OWS, OA>
-where
-    L: ArticulationLink,
-    S: RigidStatic,
-    D: RigidDynamic,
-    OC: CollisionCallback,
-    OT: TriggerCallback,
-    OCB: ConstraintBreakCallback,
-    OWS: WakeSleepCallback<L, S, D>,
-    OA: AdvanceCallback<L, D>,
-{
-    type UserData = U;
-
-    fn user_data_ptr(&self) -> &*mut c_void {
-        &self.obj.userData
+    fn into_px(self) -> Self::Target {
+        PxSceneFlags { mBits: self.bits() }
     }
 
-    fn user_data_ptr_mut(&mut self) -> &mut *mut c_void {
-        &mut self.obj.userData
-    }
-}
-
-unsafe impl<U, L, S, D, OA, OT, OWS, OC, OCB> Class<physx_sys::PxSceneDesc>
-    for PxSceneDesc<U, L, S, D, OC, OT, OCB, OWS, OA>
-where
-    L: ArticulationLink,
-    S: RigidStatic,
-    D: RigidDynamic,
-    OC: CollisionCallback,
-    OT: TriggerCallback,
-    OCB: ConstraintBreakCallback,
-    OWS: WakeSleepCallback<L, S, D>,
-    OA: AdvanceCallback<L, D>,
-{
-    fn as_ptr(&self) -> *const physx_sys::PxSceneDesc {
-        &self.obj
-    }
-
-    fn as_mut_ptr(&mut self) -> *mut physx_sys::PxSceneDesc {
-        &mut self.obj
+    fn from_px(flags: Self::Target) -> Self {
+        BitFlags::from_bits_truncate(flags.mBits)
     }
 }
 
@@ -1120,4 +1116,10 @@ pub enum FilterShaderDescriptor {
     Default,
     Custom(physx_sys::SimulationFilterShader),
     CallDefaultFirst(physx_sys::SimulationFilterShader),
+}
+
+impl Default for FilterShaderDescriptor {
+    fn default() -> Self {
+        FilterShaderDescriptor::Default
+    }
 }

--- a/physx/src/traits/descriptor.rs
+++ b/physx/src/traits/descriptor.rs
@@ -1,0 +1,395 @@
+use crate::{
+    articulation::Articulation,
+    articulation_link::ArticulationLink,
+    articulation_reduced_coordinate::ArticulationReducedCoordinate,
+    constraint::Constraint,
+    geometry::Geometry,
+    material::Material,
+    math::{PxBounds3, PxTransform, PxVec3},
+    owner::Owner,
+    physics::Physics,
+    rigid_actor::RigidActor,
+    rigid_dynamic::{PxRigidDynamic, RigidDynamic},
+    rigid_static::{PxRigidStatic, RigidStatic},
+    scene::{
+        BroadPhaseType, FilterShaderDescriptor, FrictionType, PairFilteringMode,
+        PruningStructureType, PxScene, Scene, SceneFlag, SceneLimits, SceneQueryUpdateMode,
+        SolverType,
+    },
+    shape::{Shape, ShapeFlags},
+    simulation_event_callback::{
+        AdvanceCallback, CollisionCallback, ConstraintBreakCallback, PxSimulationEventCallback,
+        TriggerCallback, WakeSleepCallback,
+    },
+    traits::{PxFlags, UserData},
+};
+
+use enumflags2::BitFlags;
+
+use std::{ffi::c_void, marker::PhantomData, mem::size_of, ptr::null_mut};
+
+pub trait Descriptor<P> {
+    type Target;
+    fn create(self, creator: &mut P) -> Self::Target;
+}
+
+pub struct SceneDescriptor<
+    U,
+    L: ArticulationLink,
+    S: RigidStatic,
+    D: RigidDynamic,
+    T: Articulation,
+    C: ArticulationReducedCoordinate,
+    OC: CollisionCallback,
+    OT: TriggerCallback,
+    OCB: ConstraintBreakCallback,
+    OWS: WakeSleepCallback<L, S, D>,
+    OA: AdvanceCallback<L, D>,
+> {
+    pub phantom_marker: PhantomData<(L, S, D, T, C)>,
+    pub user_data: U,
+    pub on_collide: Option<OC>,
+    pub on_trigger: Option<OT>,
+    pub on_constraint_break: Option<OCB>,
+    pub on_wake_sleep: Option<OWS>,
+    pub on_advance: Option<OA>,
+    pub gravity: PxVec3,
+    pub kine_kine_filtering_mode: PairFilteringMode,
+    pub static_kine_filtering_mode: PairFilteringMode,
+    pub broad_phase_type: BroadPhaseType,
+    pub limits: SceneLimits,
+    pub friction_type: FrictionType,
+    pub solver_type: SolverType,
+    pub bounce_threshold_velocity: f32,
+    pub friction_offset_threshold: f32,
+    pub ccd_max_separation: f32,
+    pub solver_offset_slop: f32,
+    pub flags: BitFlags<SceneFlag>,
+    pub static_structure: PruningStructureType,
+    pub dynamic_structure: PruningStructureType,
+    pub dynamic_tree_rebuild_rate_hint: u32,
+    pub scene_query_update_mode: SceneQueryUpdateMode,
+    pub solver_batch_size: u32,
+    pub solver_articulation_batch_size: u32,
+    pub nb_contact_data_blocks: u32,
+    pub max_nb_contact_data_blocks: u32,
+    pub max_bias_coefficient: f32,
+    pub contact_report_stream_buffer_size: u32,
+    pub ccd_max_passes: u32,
+    pub ccd_threshold: f32,
+    pub wake_counter_reset_value: f32,
+    pub sanity_bounds: PxBounds3,
+
+    pub simulation_filter_shader: FilterShaderDescriptor,
+
+    pub thread_count: u32, //pub cpu_dispatcher: *mut PxCpuDispatcher,
+    pub broad_phase_callback: *mut physx_sys::PxBroadPhaseCallback,
+    pub contact_modify_callback: *mut physx_sys::PxContactModifyCallback,
+    pub ccd_contact_modify_callback: *mut physx_sys::PxCCDContactModifyCallback,
+
+    pub cuda_context_manager: *mut physx_sys::PxCudaContextManager,
+    pub gpu_dynamics_config: physx_sys::PxgDynamicsMemoryConfig,
+    pub gpu_max_num_partitions: u32,
+    pub gpu_compute_version: u32,
+}
+
+impl<
+        U,
+        L: ArticulationLink,
+        S: RigidStatic,
+        D: RigidDynamic,
+        T: Articulation,
+        C: ArticulationReducedCoordinate,
+        OC: CollisionCallback,
+        OT: TriggerCallback,
+        OCB: ConstraintBreakCallback,
+        OWS: WakeSleepCallback<L, S, D>,
+        OA: AdvanceCallback<L, D>,
+    > SceneDescriptor<U, L, S, D, T, C, OC, OT, OCB, OWS, OA>
+{
+    pub fn new(user_data: U) -> Self {
+        Self {
+            phantom_marker: PhantomData,
+            user_data,
+            on_collide: None,
+            on_trigger: None,
+            on_constraint_break: None,
+            on_wake_sleep: None,
+            on_advance: None,
+            gravity: PxVec3::new(0.0, 0.0, 0.0),
+            kine_kine_filtering_mode: PairFilteringMode::Suppress,
+            static_kine_filtering_mode: PairFilteringMode::Suppress,
+            broad_phase_type: BroadPhaseType::AutomaticBoxPruning,
+            limits: SceneLimits {
+                max_nb_actors: 0,
+                max_nb_bodies: 0,
+                max_nb_static_shapes: 0,
+                max_nb_dynamic_shapes: 0,
+                max_nb_aggregates: 0,
+                max_nb_constraints: 0,
+                max_nb_regions: 0,
+                max_nb_broad_phase_overlaps: 0,
+            },
+            friction_type: FrictionType::Patch,
+            solver_type: SolverType::PGS,
+            bounce_threshold_velocity: 2.0,
+            friction_offset_threshold: 0.04,
+            ccd_max_separation: 0.04,
+            solver_offset_slop: 0.0,
+            flags: SceneFlag::EnablePcm.into(),
+            static_structure: PruningStructureType::DynamicAABBTree,
+            dynamic_structure: PruningStructureType::DynamicAABBTree,
+            dynamic_tree_rebuild_rate_hint: 100,
+            scene_query_update_mode: SceneQueryUpdateMode::BuildEnabledCommitEnabled,
+            solver_batch_size: 128,
+            solver_articulation_batch_size: 16,
+            nb_contact_data_blocks: 0,
+            max_nb_contact_data_blocks: 1 << 16,
+            max_bias_coefficient: f32::MAX,
+            contact_report_stream_buffer_size: 8192,
+            ccd_max_passes: 1,
+            ccd_threshold: f32::MAX,
+            wake_counter_reset_value: 0.4,
+            sanity_bounds: PxBounds3::max_bounds_extents(),
+            simulation_filter_shader: FilterShaderDescriptor::Default,
+            thread_count: 1,
+            broad_phase_callback: null_mut(),
+            contact_modify_callback: null_mut(),
+            ccd_contact_modify_callback: null_mut(),
+            cuda_context_manager: null_mut(),
+            gpu_dynamics_config: unsafe { physx_sys::PxgDynamicsMemoryConfig_new() },
+            gpu_max_num_partitions: 8,
+            gpu_compute_version: 0,
+        }
+    }
+}
+
+impl<
+        P: Physics,
+        U,
+        L: ArticulationLink,
+        S: RigidStatic,
+        D: RigidDynamic,
+        T: Articulation,
+        C: ArticulationReducedCoordinate,
+        OC: CollisionCallback,
+        OT: TriggerCallback,
+        OCB: ConstraintBreakCallback,
+        OWS: WakeSleepCallback<L, S, D>,
+        OA: AdvanceCallback<L, D>,
+    > Descriptor<P> for SceneDescriptor<U, L, S, D, T, C, OC, OT, OCB, OWS, OA>
+{
+    #[allow(clippy::type_complexity)]
+    type Target = Option<Owner<PxScene<U, L, S, D, T, C, OC, OT, OCB, OWS, OA>>>;
+
+    fn create(self, creator: &mut P) -> Self::Target {
+        let mut desc = unsafe {
+            physx_sys::PxSceneDesc {
+                gravity: self.gravity.into(),
+                limits: self.limits.into(),
+                bounceThresholdVelocity: self.bounce_threshold_velocity,
+                frictionOffsetThreshold: self.friction_offset_threshold,
+                ccdMaxSeparation: self.ccd_max_separation,
+                solverOffsetSlop: self.solver_offset_slop,
+                flags: self.flags.into_px(),
+                userData: if size_of::<U>() > size_of::<*mut c_void>() {
+                    // Too big to pack into a *mut c_void, kick it to the heap.
+                    Box::into_raw(Box::new(self.user_data)) as *mut c_void
+                } else {
+                    // DATA_SIZE <= VOID_SIZE
+                    *(&self.user_data as *const U as *const *mut c_void)
+                },
+                solverBatchSize: self.solver_batch_size,
+                solverArticulationBatchSize: self.solver_articulation_batch_size,
+                maxBiasCoefficient: self.max_bias_coefficient,
+                ccdMaxPasses: self.ccd_max_passes,
+                ccdThreshold: self.ccd_threshold,
+                wakeCounterResetValue: self.wake_counter_reset_value,
+                sanityBounds: self.sanity_bounds.into(),
+                simulationEventCallback: PxSimulationEventCallback::new(
+                    self.on_collide,
+                    self.on_trigger,
+                    self.on_constraint_break,
+                    self.on_wake_sleep,
+                    self.on_advance,
+                )?
+                .into_ptr(),
+                kineKineFilteringMode: self.kine_kine_filtering_mode.into(),
+                staticKineFilteringMode: self.static_kine_filtering_mode.into(),
+                frictionType: self.friction_type.into(),
+                solverType: self.solver_type.into(),
+                broadPhaseType: self.broad_phase_type.into(),
+                dynamicStructure: self.dynamic_structure.into(),
+                staticStructure: self.static_structure.into(),
+                dynamicTreeRebuildRateHint: self.dynamic_tree_rebuild_rate_hint,
+                sceneQueryUpdateMode: self.scene_query_update_mode.into(),
+                nbContactDataBlocks: self.nb_contact_data_blocks,
+                maxNbContactDataBlocks: self.max_nb_contact_data_blocks,
+                contactReportStreamBufferSize: self.contact_report_stream_buffer_size,
+                cpuDispatcher: physx_sys::phys_PxDefaultCpuDispatcherCreate(
+                    self.thread_count,
+                    null_mut(),
+                ) as *mut physx_sys::PxCpuDispatcher,
+                contactModifyCallback: self.contact_modify_callback,
+                ccdContactModifyCallback: self.ccd_contact_modify_callback,
+                broadPhaseCallback: self.broad_phase_callback,
+                cudaContextManager: self.cuda_context_manager,
+                gpuDynamicsConfig: self.gpu_dynamics_config,
+                gpuMaxNumPartitions: self.gpu_max_num_partitions,
+                gpuComputeVersion: self.gpu_compute_version,
+                ..physx_sys::PxSceneDesc_new(creator.get_tolerances_scale()?)
+            }
+        };
+        unsafe {
+            match self.simulation_filter_shader {
+                FilterShaderDescriptor::Default => {
+                    desc.filterShader = physx_sys::get_default_simulation_filter_shader();
+                }
+                FilterShaderDescriptor::CallDefaultFirst(shader) => {
+                    physx_sys::enable_custom_filter_shader(&mut desc, shader, 1);
+                }
+                FilterShaderDescriptor::Custom(shader) => {
+                    physx_sys::enable_custom_filter_shader(&mut desc, shader, 0);
+                }
+            }
+        };
+        unsafe {
+            Scene::from_raw(physx_sys::PxPhysics_createScene_mut(
+                creator.as_mut_ptr(),
+                &desc,
+            ))
+        }
+    }
+}
+
+pub struct ConstraintDescriptor<'a, RA: RigidActor> {
+    first_actor: &'a mut RA,
+    second_actor: &'a mut RA,
+    connector: &'a mut physx_sys::PxConstraintConnector,
+    shaders: &'a physx_sys::PxConstraintShaderTable,
+    data_size: u32,
+}
+
+impl<P: Physics, RA: RigidActor> Descriptor<P> for ConstraintDescriptor<'_, RA> {
+    type Target = Option<Owner<Constraint>>;
+
+    fn create(self, creator: &mut P) -> Self::Target {
+        creator.create_constraint(
+            self.first_actor,
+            self.second_actor,
+            self.connector,
+            self.shaders,
+            self.data_size,
+        )
+    }
+}
+
+pub struct MaterialDescriptor<U> {
+    pub static_friction: f32,
+    pub dynamic_friction: f32,
+    pub restitution: f32,
+    pub user_data: U,
+}
+
+impl<P: Physics> Descriptor<P>
+    for MaterialDescriptor<<<<P as Physics>::Shape as Shape>::Material as UserData>::UserData>
+{
+    type Target = Option<Owner<<<P as Physics>::Shape as Shape>::Material>>;
+    fn create(self, physics: &mut P) -> Self::Target {
+        physics.create_material(
+            self.static_friction,
+            self.dynamic_friction,
+            self.restitution,
+            self.user_data,
+        )
+    }
+}
+
+pub struct ShapeDescriptor<'a, U, G: Geometry, M: Material> {
+    pub geometry: &'a G,
+    pub materials: &'a mut [&'a mut M],
+    pub is_exclusive: bool,
+    pub shape_flags: ShapeFlags,
+    pub user_data: U,
+}
+
+impl<P: Physics, G: Geometry> Descriptor<P>
+    for ShapeDescriptor<'_, <P::Shape as UserData>::UserData, G, <P::Shape as Shape>::Material>
+{
+    type Target = Option<Owner<P::Shape>>;
+
+    fn create(self, creator: &mut P) -> Self::Target {
+        creator.create_shape(
+            self.geometry,
+            self.materials,
+            self.is_exclusive,
+            self.shape_flags,
+            self.user_data,
+        )
+    }
+}
+
+pub struct RigidDynamicDescriptor<'a, U, G: Geometry, M: Material> {
+    pub transform: PxTransform,
+    pub geometry: &'a G,
+    pub material: &'a mut M,
+    pub density: f32,
+    pub shape_transform: PxTransform,
+    pub user_data: U,
+}
+
+impl<P: Physics, U, G: Geometry> Descriptor<P>
+    for RigidDynamicDescriptor<'_, U, G, <P::Shape as Shape>::Material>
+{
+    type Target = Option<Owner<PxRigidDynamic<U, P::Shape>>>;
+
+    fn create(self, creator: &mut P) -> Self::Target {
+        creator.create_rigid_dynamic(
+            self.transform,
+            self.geometry,
+            self.material,
+            self.density,
+            self.shape_transform,
+            self.user_data,
+        )
+    }
+}
+
+pub struct RigidStaticDescriptor<'a, U, G: Geometry, M: Material> {
+    pub transform: PxTransform,
+    pub geometry: &'a G,
+    pub material: &'a mut M,
+    pub shape_transform: PxTransform,
+    pub user_data: U,
+}
+
+impl<P: Physics, U, G: Geometry> Descriptor<P>
+    for RigidStaticDescriptor<'_, U, G, <P::Shape as Shape>::Material>
+{
+    type Target = Option<Owner<PxRigidStatic<U, P::Shape>>>;
+
+    fn create(self, creator: &mut P) -> Self::Target {
+        creator.create_rigid_static(
+            self.transform,
+            self.geometry,
+            self.material,
+            self.shape_transform,
+            self.user_data,
+        )
+    }
+}
+
+pub struct PlaneDescriptor<'a, U, M: Material> {
+    pub normal: PxVec3,
+    pub offset: f32,
+    pub material: &'a mut M,
+    pub user_data: U,
+}
+
+impl<P: Physics, U> Descriptor<P> for PlaneDescriptor<'_, U, <P::Shape as Shape>::Material> {
+    type Target = Option<Owner<PxRigidStatic<U, P::Shape>>>;
+
+    fn create(self, creator: &mut P) -> Self::Target {
+        creator.create_plane(self.normal, self.offset, self.material, self.user_data)
+    }
+}

--- a/physx/src/traits/mod.rs
+++ b/physx/src/traits/mod.rs
@@ -14,6 +14,9 @@ pub use class::Class;
 mod user_data;
 pub(crate) use user_data::UserData;
 
+pub mod descriptor;
+pub(crate) use descriptor::*;
+
 pub trait PxFlags: Copy {
     /// The target physx_sys flags type.
     type Target;
@@ -21,9 +24,4 @@ pub trait PxFlags: Copy {
     fn into_px(self) -> Self::Target;
     /// Convert to BitFlags<> type.
     fn from_px(flags: Self::Target) -> Self;
-}
-
-pub(crate) trait IntoPx {
-    type Target;
-    unsafe fn into_px(self) -> Self::Target;
 }

--- a/physx/src/triangle_mesh.rs
+++ b/physx/src/triangle_mesh.rs
@@ -14,9 +14,7 @@ impl TriangleMesh {
     /// Owner's own the pointer they wrap, using the pointer after dropping the Owner,
     /// or creating multiple Owners from the same pointer will cause UB.  Use `into_ptr` to
     /// retrieve the pointer and consume the Owner without dropping the pointee.
-    pub(crate) unsafe fn from_raw(
-        ptr: *mut physx_sys::PxTriangleMesh,
-    ) -> Option<Owner<TriangleMesh>> {
+    pub unsafe fn from_raw(ptr: *mut physx_sys::PxTriangleMesh) -> Option<Owner<TriangleMesh>> {
         Owner::from_raw(ptr as *mut Self)
     }
 }


### PR DESCRIPTION
First round of changes. Will require a major API version bump once it's all in.

Generally this wasn't too bad but there are holes.

A lot of the SceneDesc parameters were lost, added back a few. It's gonna be more though, so should we add a builder?


Now includes @Hentropy 's new object creation rework.