### PR TITLE
impl Physics for PhysicsFoundation update readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Rust binding and wrapper over [NVIDIA PhysX](https://github.com/NVIDIAGameWorks/
 
 Created and maintained by [Embark](http://embark.games) and _**not**_ officially supported by NVIDIA.
 
-This repository contains 3 crates:
+This repository contains 2 crates:
 
 | Name | Description | Links |
 | --- | --- | --- |
 | [`physx`](physx/) | High-level interface on top of `physx-sys` 🚧 | [![Crates.io](https://img.shields.io/crates/v/physx.svg)](https://crates.io/crates/physx) [![Docs](https://docs.rs/physx/badge.svg)](https://docs.rs/physx) |
 | [`physx-sys`](physx-sys/) | Unsafe bindings to the [PhysX C++ API](https://github.com/NVIDIAGameWorks/PhysX) | [![Crates.io](https://img.shields.io/crates/v/physx-sys.svg)](https://crates.io/crates/physx-sys) [![Docs](https://docs.rs/physx-sys/badge.svg)](https://docs.rs/physx-sys) |
-| [`physx-macros`](physx-macros/) | Utility macros used internally by the `physx` crate | [![Crates.io](https://img.shields.io/crates/v/physx-macros.svg)](https://crates.io/crates/physx-macros) [![Docs](https://docs.rs/physx-macros/badge.svg)](https://docs.rs/physx-macros) |
+
 
 ## Why use it?
 
@@ -33,7 +33,9 @@ This repository contains 3 crates:
 
 ### Alternatives
 
-* [nphysics](https://github.com/rustsim/nphysics): a 2- and 3-dimensional physics engine for games and animations written in Rust. It is a good option for projects which do not require the full feature set of PhysX or prefer a native Rust solution.
+* [Rapier](https://github.com/dimforge/rapier): a 2D and 3D physics engine for games, animation, and robotics written in Rust.  Fully cross-platform, with web support and optional cross-platform determinism on IEEE 754-2008 compliant systems.
+
+* [nphysics](https://github.com/dimforge/nphysics): a 2- and 3-dimensional physics engine for games and animations written in Rust. It is a good option for projects which do not require the full feature set of PhysX or prefer a native Rust solution.
 
 ## Presentation
 
@@ -49,14 +51,13 @@ The following code example shows how [`physx`](physx/) can be initialized.
 const PX_PHYSICS_VERSION: u32 = physx::version(4, 1, 1);
 let mut foundation = Foundation::new(PX_PHYSICS_VERSION);
 
-let mut physics = PhysicsBuilder::default()
-    .load_extensions(false) // switch this flag to load extensions during setup
-    .build(&mut foundation);
+let mut physics = PhysicsFoundation::default();
 
-let mut scene = physics.create_scene(
-    SceneBuilder::default()
-        .set_gravity(glm::vec3(0.0, -9.81, 0.0))
-        .set_simulation_threading(SimulationThreadType::Dedicated(1)),
+let mut scene = physics.create(
+    SceneDescriptor {
+        gravity: PxVec3::new(0.0, 0.0, -9.81),
+        ..SceneDescriptor::new(MySceneUserData::default())
+    }
 );
 
 ```

--- a/physx/examples/ball_physx.rs
+++ b/physx/examples/ball_physx.rs
@@ -80,9 +80,7 @@ fn main() {
     // Holds a PxFoundation and a PxPhysics.
     // Also has an optional Pvd and transport, not enabled by default.
     // The default allocator is the one provided by PhysX.
-    let mut physics_foundation = PhysicsFoundation::<_, PxShape>::default();
-
-    let physics = physics_foundation.physics_mut();
+    let mut physics = PhysicsFoundation::<_, PxShape>::default();
 
     // Setup the scene object.  The PxScene type alias makes this much cleaner.
     // There are lots of unwrap calls due to potential null pointers.

--- a/physx/src/physics.rs
+++ b/physx/src/physics.rs
@@ -105,6 +105,24 @@ pub struct PhysicsFoundation<Allocator: AllocatorCallback, Geom: Shape> {
     extensions_loaded: bool,
 }
 
+unsafe impl<T, Allocator: AllocatorCallback, Geom: Shape> Class<T>
+    for PhysicsFoundation<Allocator, Geom>
+where
+    physx_sys::PxPhysics: Class<T>,
+{
+    fn as_ptr(&self) -> *const T {
+        self.physics.obj.as_ptr()
+    }
+
+    fn as_mut_ptr(&mut self) -> *mut T {
+        self.physics.obj.as_mut_ptr()
+    }
+}
+
+impl<Allocator: AllocatorCallback, Geom: Shape> Physics for PhysicsFoundation<Allocator, Geom> {
+    type Shape = Geom;
+}
+
 impl<Allocator: AllocatorCallback, Geom: Shape> PhysicsFoundation<Allocator, Geom> {
     pub fn new(allocator: Allocator) -> PhysicsFoundation<Allocator, Geom> {
         let mut foundation =


### PR DESCRIPTION
Implementing `Physics` for `PhysicsFoundation` makes the API feel much cleaner, calling a method to retrieve the `Physics` object was annoying.  `Foundation` and `Pvd` could be implemented as well, but they aren't used as frequently.

This also updates the readmes code examples, explanations and alternatives list.

builds on #113 