### PR TITLE
Add initial support for scene raycast, sweep, and overlap

### DIFF
--- a/physx-sys/src/lib.rs
+++ b/physx-sys/src/lib.rs
@@ -285,16 +285,22 @@ extern "C" {
     pub fn create_raycast_callback(
         process_touches_callback: RaycastProcessTouchesCallback,
         finalize_query_callback: FinalizeQueryCallback,
+        touches_buffer: *mut PxRaycastHit,
+        num_touches: u32,
         userdata: *mut c_void,
     ) -> *mut PxRaycastCallback;
     pub fn create_sweep_callback(
         process_touches_callback: SweepProcessTouchesCallback,
         finalize_query_callback: FinalizeQueryCallback,
+        touches_buffer: *mut PxSweepHit,
+        num_touches: u32,
         userdata: *mut c_void,
     ) -> *mut PxSweepCallback;
     pub fn create_overlap_callback(
         process_touches_callback: OverlapProcessTouchesCallback,
         finalize_query_callback: FinalizeQueryCallback,
+        touches_buffer: *mut PxOverlapHit,
+        num_touches: u32,
         userdata: *mut c_void,
     ) -> *mut PxOverlapCallback;
 

--- a/physx-sys/src/lib.rs
+++ b/physx-sys/src/lib.rs
@@ -241,7 +241,18 @@ pub struct FilterShaderCallbackInfo {
     pub constantBlockSize: u32,
 }
 
+pub type PxAgain = bool;
+
 pub type SimulationFilterShader = unsafe extern "C" fn(*mut FilterShaderCallbackInfo) -> u16;
+
+pub type RaycastProcessTouchesCallback =
+    unsafe extern "C" fn(*const PxRaycastHit, u32, *const c_void) -> PxAgain;
+pub type SweepProcessTouchesCallback =
+    unsafe extern "C" fn(*const PxSweepHit, u32, *const c_void) -> PxAgain;
+pub type OverlapProcessTouchesCallback =
+    unsafe extern "C" fn(*const PxOverlapHit, u32, *const c_void) -> PxAgain;
+
+pub type FinalizeQueryCallback = unsafe extern "C" fn(*const c_void);
 
 pub type AllocCallback =
     unsafe extern "C" fn(u64, *const c_void, *const c_void, u32, *const c_void) -> *mut c_void;
@@ -268,6 +279,26 @@ extern "C" {
         callback: RaycastHitCallback,
         userdata: *mut c_void,
     ) -> *mut PxQueryFilterCallback;
+
+    pub fn create_raycast_buffer() -> *mut PxRaycastCallback;
+    pub fn create_sweep_buffer() -> *mut PxSweepCallback;
+    pub fn create_overlap_buffer() -> *mut PxOverlapCallback;
+
+    pub fn create_raycast_callback(
+        process_touches_callback: RaycastProcessTouchesCallback,
+        finalize_query_callback: FinalizeQueryCallback,
+        userdata: *mut c_void,
+    ) -> *mut PxRaycastCallback;
+    pub fn create_sweep_callback(
+        process_touches_callback: SweepProcessTouchesCallback,
+        finalize_query_callback: FinalizeQueryCallback,
+        userdata: *mut c_void,
+    ) -> *mut PxSweepCallback;
+    pub fn create_overlap_callback(
+        process_touches_callback: OverlapProcessTouchesCallback,
+        finalize_query_callback: FinalizeQueryCallback,
+        userdata: *mut c_void,
+    ) -> *mut PxOverlapCallback;
 
     pub fn create_alloc_callback(
         alloc_callback: AllocCallback,

--- a/physx-sys/src/lib.rs
+++ b/physx-sys/src/lib.rs
@@ -305,6 +305,8 @@ extern "C" {
     ) -> *mut PxOverlapCallback;
 
     pub fn delete_raycast_callback(callback: *mut PxRaycastCallback);
+    pub fn delete_sweep_callback(callback: *mut PxSweepCallback);
+    pub fn delete_overlap_callback(callback: *mut PxOverlapCallback);
 
     pub fn create_alloc_callback(
         alloc_callback: AllocCallback,

--- a/physx-sys/src/lib.rs
+++ b/physx-sys/src/lib.rs
@@ -241,16 +241,14 @@ pub struct FilterShaderCallbackInfo {
     pub constantBlockSize: u32,
 }
 
-pub type PxAgain = bool;
-
 pub type SimulationFilterShader = unsafe extern "C" fn(*mut FilterShaderCallbackInfo) -> u16;
 
 pub type RaycastProcessTouchesCallback =
-    unsafe extern "C" fn(*const PxRaycastHit, u32, *const c_void) -> PxAgain;
+    unsafe extern "C" fn(*const PxRaycastHit, u32, *const c_void) -> bool;
 pub type SweepProcessTouchesCallback =
-    unsafe extern "C" fn(*const PxSweepHit, u32, *const c_void) -> PxAgain;
+    unsafe extern "C" fn(*const PxSweepHit, u32, *const c_void) -> bool;
 pub type OverlapProcessTouchesCallback =
-    unsafe extern "C" fn(*const PxOverlapHit, u32, *const c_void) -> PxAgain;
+    unsafe extern "C" fn(*const PxOverlapHit, u32, *const c_void) -> bool;
 
 pub type FinalizeQueryCallback = unsafe extern "C" fn(*const c_void);
 

--- a/physx-sys/src/lib.rs
+++ b/physx-sys/src/lib.rs
@@ -304,6 +304,8 @@ extern "C" {
         userdata: *mut c_void,
     ) -> *mut PxOverlapCallback;
 
+    pub fn delete_raycast_callback(callback: *mut PxRaycastCallback);
+
     pub fn create_alloc_callback(
         alloc_callback: AllocCallback,
         dealloc_callback: DeallocCallback,

--- a/physx-sys/src/lib.rs
+++ b/physx-sys/src/lib.rs
@@ -244,13 +244,13 @@ pub struct FilterShaderCallbackInfo {
 pub type SimulationFilterShader = unsafe extern "C" fn(*mut FilterShaderCallbackInfo) -> u16;
 
 pub type RaycastProcessTouchesCallback =
-    unsafe extern "C" fn(*const PxRaycastHit, u32, *const c_void) -> bool;
+    unsafe extern "C" fn(*const PxRaycastHit, u32, *mut c_void) -> bool;
 pub type SweepProcessTouchesCallback =
-    unsafe extern "C" fn(*const PxSweepHit, u32, *const c_void) -> bool;
+    unsafe extern "C" fn(*const PxSweepHit, u32, *mut c_void) -> bool;
 pub type OverlapProcessTouchesCallback =
-    unsafe extern "C" fn(*const PxOverlapHit, u32, *const c_void) -> bool;
+    unsafe extern "C" fn(*const PxOverlapHit, u32, *mut c_void) -> bool;
 
-pub type FinalizeQueryCallback = unsafe extern "C" fn(*const c_void);
+pub type FinalizeQueryCallback = unsafe extern "C" fn(*mut c_void);
 
 pub type AllocCallback =
     unsafe extern "C" fn(u64, *const c_void, *const c_void, u32, *const c_void) -> *mut c_void;

--- a/physx-sys/src/physx_api.cpp
+++ b/physx-sys/src/physx_api.cpp
@@ -365,6 +365,16 @@ extern "C"
         delete callback;
     }
 
+    void delete_sweep_callback(PxSweepCallback *callback)
+    {
+        delete callback;
+    }
+
+    void delete_overlap_callback(PxOverlapCallback *callback)
+    {
+        delete callback;
+    }
+
     PxSweepCallback *create_sweep_callback(
         SweepHitProcessTouchesCallback process_touches_callback,
         HitFinalizeQueryCallback finalize_query_callback,

--- a/physx-sys/src/physx_api.cpp
+++ b/physx-sys/src/physx_api.cpp
@@ -360,6 +360,11 @@ extern "C"
             process_touches_callback, finalize_query_callback, touchesBuffer, numTouches, userdata);
     }
 
+    void delete_raycast_callback(PxRaycastCallback *callback)
+    {
+        delete callback;
+    }
+
     PxSweepCallback *create_sweep_callback(
         SweepHitProcessTouchesCallback process_touches_callback,
         HitFinalizeQueryCallback finalize_query_callback,

--- a/physx/examples/scene_queries.rs
+++ b/physx/examples/scene_queries.rs
@@ -1,0 +1,251 @@
+// Author: Nick Caplinger <the.nick.caplinger@gmail.com>
+// Copyright © 2020, Embark Studios, all rights reserved.
+// Created:  8 December 2020
+
+use glam::Vec3;
+use physx::prelude::*;
+use physx::query::{
+    OverlapCallback, PxOverlapBuffer, PxQueryFilterData, PxRaycastBuffer, PxSweepBuffer,
+    RaycastCallback, SweepCallback,
+};
+use physx::scene::HitFlag;
+use std::ffi::c_void;
+
+/// This is an example demonstrating the usage of scene queries within the physx crate.
+/// This includes raycast, sweep, and overlap tests.
+type PxMaterial = physx::material::PxMaterial<()>;
+type PxShape = physx::shape::PxShape<(), PxMaterial>;
+type PxArticulationLink = physx::articulation_link::PxArticulationLink<(), PxShape>;
+type PxRigidStatic = physx::rigid_static::PxRigidStatic<(), PxShape>;
+type PxRigidDynamic = physx::rigid_dynamic::PxRigidDynamic<(), PxShape>;
+type PxArticulation = physx::articulation::PxArticulation<(), PxArticulationLink>;
+type PxArticulationReducedCoordinate =
+    physx::articulation_reduced_coordinate::PxArticulationReducedCoordinate<(), PxArticulationLink>;
+type PxScene = physx::scene::PxScene<
+    (),
+    PxArticulationLink,
+    PxRigidStatic,
+    PxRigidDynamic,
+    PxArticulation,
+    PxArticulationReducedCoordinate,
+    OnCollision,
+    OnTrigger,
+    OnConstraintBreak,
+    OnWakeSleep,
+    OnAdvance,
+>;
+
+/// Next up, the simulation event callbacks need to be defined, and possibly an
+/// allocator callback as well.
+struct OnCollision;
+impl CollisionCallback for OnCollision {
+    fn on_collision(
+        &mut self,
+        _header: &physx_sys::PxContactPairHeader,
+        _pairs: &[physx_sys::PxContactPair],
+    ) {
+    }
+}
+struct OnTrigger;
+impl TriggerCallback for OnTrigger {
+    fn on_trigger(&mut self, _pairs: &[physx_sys::PxTriggerPair]) {}
+}
+
+struct OnConstraintBreak;
+impl ConstraintBreakCallback for OnConstraintBreak {
+    fn on_constraint_break(&mut self, _constraints: &[physx_sys::PxConstraintInfo]) {}
+}
+struct OnWakeSleep;
+impl WakeSleepCallback<PxArticulationLink, PxRigidStatic, PxRigidDynamic> for OnWakeSleep {
+    fn on_wake_sleep(
+        &mut self,
+        _actors: &[&physx::actor::ActorMap<PxArticulationLink, PxRigidStatic, PxRigidDynamic>],
+        _is_waking: bool,
+    ) {
+    }
+}
+
+struct OnAdvance;
+impl AdvanceCallback<PxArticulationLink, PxRigidDynamic> for OnAdvance {
+    fn on_advance(
+        &self,
+        _actors: &[&physx::rigid_body::RigidBodyMap<PxArticulationLink, PxRigidDynamic>],
+        _transforms: &[PxTransform],
+    ) {
+    }
+}
+
+struct MyRaycastCallback;
+
+unsafe impl RaycastCallback for MyRaycastCallback {
+    unsafe fn new() -> Self {
+        Self {}
+    }
+
+    unsafe fn get_raycast_hit(&mut self) -> Option<physx_sys::PxRaycastHit> {
+        None
+    }
+
+    unsafe extern "C" fn process_touches(
+        _buffer: *const physx_sys::PxRaycastHit,
+        _num_hits: u32,
+        _user_data: *const c_void,
+    ) -> bool {
+        println!("custom process_touches logic happens here");
+        false
+    }
+
+    /// # Safety
+    /// Must not panic.
+    unsafe extern "C" fn finalize_query(_user_data: *const c_void) {
+        println!("custom finalize_query logic happens here");
+    }
+}
+
+fn main() {
+    // Holds a PxFoundation and a PxPhysics.
+    // Also has an optional Pvd and transport, not enabled by default.
+    // The default allocator is the one provided by PhysX.
+    let mut physics = PhysicsFoundation::<_, PxShape>::default();
+
+    // Setup the scene object.  The PxScene type alias makes this much cleaner.
+    // There are lots of unwrap calls due to potential null pointers.
+    let mut scene: Owner<PxScene> = physics
+        .create(SceneDescriptor {
+            gravity: PxVec3::new(0.0, -9.81, 0.0),
+            on_advance: Some(OnAdvance),
+            ..SceneDescriptor::new(())
+        })
+        .unwrap();
+
+    let mut material = physics.create_material(0.5, 0.5, 0.6, ()).unwrap();
+
+    let ground_plane = physics
+        .create_plane(Vec3::new(0.0, 1.0, 0.0).into(), 0.0, material.as_mut(), ())
+        .unwrap();
+    // The scene owns actors that are added to it.  They can be retrieved using the
+    // various getters on the scene.
+    scene.add_static_actor(ground_plane);
+
+    let sphere_geo = PxSphereGeometry::new(10.0);
+    let sphere_pos = Vec3::new(0.0, 40.0, 100.0);
+
+    let mut sphere_actor = physics
+        .create_rigid_dynamic(
+            PxTransform::from_translation(&sphere_pos.into()),
+            &sphere_geo,
+            material.as_mut(),
+            10.0,
+            PxTransform::default(),
+            (),
+        )
+        .unwrap();
+    sphere_actor.set_angular_damping(0.5);
+    sphere_actor.set_rigid_body_flag(RigidBodyFlag::EnablePoseIntegrationPreview, true);
+    scene.add_dynamic_actor(sphere_actor);
+
+    // Do some scene queries
+    let origin = sphere_pos + Vec3::new(0.0, 100.0, 0.0);
+    let up_dir = Vec3::new(0.0, 1.0, 0.0);
+    let down_dir = -up_dir;
+    let distance = 5000.0;
+    unsafe {
+        // Raycasts
+        let mut hit = PxRaycastBuffer::new();
+        let hit_flags = HitFlag::default_hit_flags();
+        let filter_data = PxQueryFilterData::default();
+
+        let mut custom_hit = MyRaycastCallback::new();
+
+        let did_ray_hit = scene.raycast(
+            &origin.into(),
+            &down_dir.into(),
+            distance,
+            &mut hit,
+            hit_flags,
+            &filter_data,
+            None,
+            None,
+        );
+        assert!(did_ray_hit); // hits dynamic sphere in scene
+
+        // Let's see some info about the hit
+        let hit_info = hit.get_raycast_hit().unwrap();
+        dbg!(hit_info.distance);
+        // dbg!(PxVec3::from(hit_info.position));
+        // dbg!(PxVec3::from(hit_info.normal));
+
+        let did_ray_hit = scene.raycast(
+            &origin.into(),
+            &down_dir.into(),
+            distance,
+            &mut custom_hit,
+            hit_flags,
+            &filter_data,
+            None,
+            None,
+        );
+        assert!(did_ray_hit); // hits dynamic sphere in scene
+
+        let did_ray_hit = scene.raycast(
+            &origin.into(),
+            &up_dir.into(),
+            distance,
+            &mut hit,
+            hit_flags,
+            &filter_data,
+            None,
+            None,
+        );
+        assert!(!did_ray_hit); // raycast upward does not hit anything
+
+        // Overlaps
+        let mut overlap_callback = PxOverlapBuffer::new();
+        let did_overlap = scene.overlap(
+            &sphere_geo,
+            &PxTransform::default(),
+            &mut overlap_callback,
+            &filter_data,
+            None,
+        );
+        assert!(did_overlap); // overlaps with ground plane
+
+        let did_overlap = scene.overlap(
+            &sphere_geo,
+            &PxTransform::from_translation(&Vec3::new(0.0, 30.0, 0.0).into()),
+            &mut overlap_callback,
+            &filter_data,
+            None,
+        );
+        assert!(!did_overlap); // midair sphere overlaps with nothing
+
+        let mut sweep_callback = PxSweepBuffer::new();
+        let did_sweep_hit = scene.sweep(
+            &sphere_geo,
+            &PxTransform::from_translation(&Vec3::new(0.0, 30.0, 0.0).into()),
+            &down_dir.into(),
+            60.0,
+            &mut sweep_callback,
+            hit_flags,
+            &filter_data,
+            None,
+            None,
+            0.0,
+        );
+        assert!(did_sweep_hit); // sweeping through the plane should hit
+
+        let did_sweep_hit = scene.sweep(
+            &sphere_geo,
+            &PxTransform::from_translation(&Vec3::new(0.0, 30.0, 0.0).into()),
+            &up_dir.into(),
+            60.0,
+            &mut sweep_callback,
+            hit_flags,
+            &filter_data,
+            None,
+            None,
+            0.0,
+        );
+        assert!(!did_sweep_hit); // sweeping upward should not hit anything
+    }
+}

--- a/physx/examples/scene_queries.rs
+++ b/physx/examples/scene_queries.rs
@@ -163,7 +163,12 @@ fn main() {
         u: 0.0,
         v: 0.0,
     };
-    let mut touch_buffer = [default_touch_buffer; 16];
+
+    // NOTE touch_buffer is used as the backing storage for the callback.
+    //      It can be allocated however you see fit.
+    // let mut touch_buffer = [default_touch_buffer; 16];
+    let mut touch_buffer = vec![default_touch_buffer; 128];
+
     let mut custom_hit_callbacks = PositionCollectorRaycastCallback::default();
     let mut custom_hit = PxRaycastCallback::with_user_callbacks(&mut custom_hit_callbacks, Some(&mut touch_buffer));
 
@@ -196,6 +201,10 @@ fn main() {
         None,
     );
     assert!(did_ray_hit); // hits dynamic sphere in scene
+
+    // NOTE touch_buffer is borrowed for the duration of the PxRaycastCallback's lifetime!
+    //      Uncommenting this line will cause a build error.
+    // touch_buffer.clear();
 
     for position in &custom_hit_callbacks.positions {
         println!("position: {}, {}, {}", position.x(), position.y(), position.z());

--- a/physx/examples/scene_queries.rs
+++ b/physx/examples/scene_queries.rs
@@ -172,24 +172,6 @@ fn main() {
     let mut custom_hit_callbacks = PositionCollectorRaycastCallback::default();
     let mut custom_hit = PxRaycastCallback::with_user_callbacks(&mut custom_hit_callbacks, Some(&mut touch_buffer));
 
-    // let did_ray_hit = scene.raycast(
-    //     &origin.into(),
-    //     &down_dir.into(),
-    //     distance,
-    //     &mut hit,
-    //     hit_flags,
-    //     &filter_data,
-    //     None,
-    //     None,
-    // );
-    // assert!(did_ray_hit); // hits dynamic sphere in scene
-
-    // // Let's see some info about the hit
-    // let hit_info = hit.get_raycast_hit().unwrap();
-    // dbg!(hit_info.distance);
-    // // dbg!(PxVec3::from(hit_info.position));
-    // // dbg!(PxVec3::from(hit_info.normal));
-
     let did_ray_hit = scene.raycast(
         &origin.into(),
         &down_dir.into(),

--- a/physx/examples/scene_queries.rs
+++ b/physx/examples/scene_queries.rs
@@ -86,6 +86,9 @@ impl RaycastCallback for PositionCollectorRaycastCallback {
         for touch in touches {
             self.positions.push(touch.position.into());
         }
+
+        // We should return true if we determine that the touched object should block further hits
+        // For our example callback, we'll just collected all the touched objects
         false
     }
 
@@ -194,6 +197,20 @@ fn main() {
     );
     assert!(did_ray_hit); // hits dynamic sphere in scene
 
+    for position in &custom_hit_callbacks.positions {
+        println!("position: {}, {}, {}", position.x(), position.y(), position.z());
+    }
+
+    if let Some(touches) = custom_hit.get_touching_hits() {
+        for touch in touches {
+            println!("touch position: {}, {}, {}", touch.position.x, touch.position.y, touch.position.z);
+        }
+    }
+
+    if let Some(blocker) = custom_hit.get_blocking_hit() {
+        println!("blocker position: {}, {}, {}", blocker.position.x, blocker.position.y, blocker.position.z);
+    }
+
     custom_hit_callbacks.positions.clear();
     let did_ray_hit = scene.raycast(
         &origin.into(),
@@ -222,7 +239,7 @@ fn main() {
         );
 
         if let Some(blocker) = simple_hit_callback.get_blocking_hit() {
-            println!("position: {}, {}, {}", blocker.position.x, blocker.position.y, blocker.position.z);
+            println!("blocker position: {}, {}, {}", blocker.position.x, blocker.position.y, blocker.position.z);
         }
     }
 

--- a/physx/examples/scene_queries.rs
+++ b/physx/examples/scene_queries.rs
@@ -4,9 +4,7 @@
 
 use glam::Vec3;
 use physx::prelude::*;
-use physx::query::{
-    PxQueryFilterData, RaycastCallback, PxRaycastCallback, RaycastCallbackDefault,
-};
+use physx::query::{PxQueryFilterData, PxRaycastCallback, RaycastCallback, RaycastCallbackDefault};
 use physx::scene::HitFlag;
 use physx::traits::PxFlags;
 
@@ -81,7 +79,6 @@ struct PositionCollectorRaycastCallback {
 }
 
 impl RaycastCallback for PositionCollectorRaycastCallback {
-
     fn process_touches(&mut self, touches: &[physx_sys::PxRaycastHit]) -> bool {
         for touch in touches {
             self.positions.push(touch.position.into());
@@ -146,7 +143,6 @@ fn main() {
     let distance = 5000.0;
 
     // Raycasts
-//    let mut hit = PxRaycastBuffer::new();
     let hit_flags = HitFlag::default_hit_flags();
     let filter_data = PxQueryFilterData::default();
 
@@ -170,7 +166,8 @@ fn main() {
     let mut touch_buffer = vec![default_touch_buffer; 128];
 
     let mut custom_hit_callbacks = PositionCollectorRaycastCallback::default();
-    let mut custom_hit = PxRaycastCallback::with_user_callbacks(&mut custom_hit_callbacks, Some(&mut touch_buffer));
+    let mut custom_hit =
+        PxRaycastCallback::with_user_callbacks(&mut custom_hit_callbacks, Some(&mut touch_buffer));
 
     let did_ray_hit = scene.raycast(
         &origin.into(),
@@ -189,17 +186,28 @@ fn main() {
     // touch_buffer.clear();
 
     for position in &custom_hit_callbacks.positions {
-        println!("position: {}, {}, {}", position.x(), position.y(), position.z());
+        println!(
+            "position: {}, {}, {}",
+            position.x(),
+            position.y(),
+            position.z()
+        );
     }
 
     if let Some(touches) = custom_hit.get_touching_hits() {
         for touch in touches {
-            println!("touch position: {}, {}, {}", touch.position.x, touch.position.y, touch.position.z);
+            println!(
+                "touch position: {}, {}, {}",
+                touch.position.x, touch.position.y, touch.position.z
+            );
         }
     }
 
     if let Some(blocker) = custom_hit.get_blocking_hit() {
-        println!("blocker position: {}, {}, {}", blocker.position.x, blocker.position.y, blocker.position.z);
+        println!(
+            "blocker position: {}, {}, {}",
+            blocker.position.x, blocker.position.y, blocker.position.z
+        );
     }
 
     custom_hit_callbacks.positions.clear();
@@ -230,7 +238,10 @@ fn main() {
         );
 
         if let Some(blocker) = simple_hit_callback.get_blocking_hit() {
-            println!("blocker position: {}, {}, {}", blocker.position.x, blocker.position.y, blocker.position.z);
+            println!(
+                "blocker position: {}, {}, {}",
+                blocker.position.x, blocker.position.y, blocker.position.z
+            );
         }
     }
 

--- a/physx/src/foundation.rs
+++ b/physx/src/foundation.rs
@@ -38,7 +38,7 @@ pub enum ErrorCode {
     PerfWarning = 128u32,
 }
 
-/// A new type wrapper for PxFoundation.  Parametrized by it's Allocator type.
+/// A new type wrapper for PxFoundation parameterized by its Allocator type.
 #[repr(transparent)]
 pub struct PxFoundation<Allocator: AllocatorCallback> {
     obj: physx_sys::PxFoundation,

--- a/physx/src/lib.rs
+++ b/physx/src/lib.rs
@@ -131,6 +131,7 @@ pub mod material;
 pub mod owner;
 pub mod physics;
 pub mod pruning_structure;
+pub mod query;
 pub mod rigid_actor;
 pub mod rigid_body;
 pub mod rigid_dynamic;

--- a/physx/src/prelude.rs
+++ b/physx/src/prelude.rs
@@ -31,6 +31,7 @@ pub use crate::height_field::*;
 pub use crate::math::*;
 pub use crate::owner::Owner;
 pub use crate::physics::{Physics, PhysicsFoundation, PX_PHYSICS_VERSION};
+pub use crate::query::PxRaycastBuffer;
 pub use crate::rigid_actor::RigidActor;
 pub use crate::rigid_body::{ForceMode, RigidBody, RigidBodyFlag, RigidBodyFlags};
 pub use crate::rigid_dynamic::{RigidDynamic, RigidDynamicLockFlag, RigidDynamicLockFlags};

--- a/physx/src/prelude.rs
+++ b/physx/src/prelude.rs
@@ -31,7 +31,7 @@ pub use crate::height_field::*;
 pub use crate::math::*;
 pub use crate::owner::Owner;
 pub use crate::physics::{Physics, PhysicsFoundation, PX_PHYSICS_VERSION};
-pub use crate::query::PxRaycastBuffer;
+// pub use crate::query::PxRaycastBuffer;
 pub use crate::rigid_actor::RigidActor;
 pub use crate::rigid_body::{ForceMode, RigidBody, RigidBodyFlag, RigidBodyFlags};
 pub use crate::rigid_dynamic::{RigidDynamic, RigidDynamicLockFlag, RigidDynamicLockFlags};

--- a/physx/src/prelude.rs
+++ b/physx/src/prelude.rs
@@ -31,7 +31,6 @@ pub use crate::height_field::*;
 pub use crate::math::*;
 pub use crate::owner::Owner;
 pub use crate::physics::{Physics, PhysicsFoundation, PX_PHYSICS_VERSION};
-// pub use crate::query::PxRaycastBuffer;
 pub use crate::rigid_actor::RigidActor;
 pub use crate::rigid_body::{ForceMode, RigidBody, RigidBodyFlag, RigidBodyFlags};
 pub use crate::rigid_dynamic::{RigidDynamic, RigidDynamicLockFlag, RigidDynamicLockFlags};

--- a/physx/src/query.rs
+++ b/physx/src/query.rs
@@ -7,7 +7,7 @@
 use crate::{owner::Owner, traits::Class};
 use physx_sys::{
     create_overlap_buffer, create_overlap_callback, create_raycast_buffer, create_raycast_callback,
-    create_sweep_buffer, create_sweep_callback,
+    create_sweep_buffer, create_sweep_callback, delete_raycast_callback
 };
 use std::ffi::c_void;
 use std::{slice, marker::PhantomData};
@@ -37,23 +37,55 @@ impl Into<physx_sys::PxQueryFilterData> for PxQueryFilterData {
     }
 }
 
-// pub struct PxRaycastHit
+pub struct RaycastCallbackDefault;
+
+impl RaycastCallback for RaycastCallbackDefault {
+    fn process_touches(&mut self, touches: &[physx_sys::PxRaycastHit]) -> bool {
+        unimplemented!()
+    }
+    fn finalize_query(&mut self) {
+        unimplemented!()
+    }
+}
 
 pub struct PxRaycastCallback<T: RaycastCallback> {
     pub(crate) obj: Option<Owner<physx_sys::PxRaycastCallback>>,
-    phantom_user_data: PhantomData<T>,
+    phantom_user_callback: PhantomData<T>,
+}
+
+impl<T: RaycastCallback> Drop for PxRaycastCallback<T> {
+    fn drop(&mut self) {
+        if let Some(obj) = &mut self.obj {
+            unsafe {
+                delete_raycast_callback(obj.as_mut_ptr());
+            }
+        }
+    }
 }
 
 impl<T: RaycastCallback> PxRaycastCallback<T> {
 
-    pub fn new(user_data: &mut T, touch_buffer: Option<&mut [physx_sys::PxRaycastHit]>) -> Self {
+    // pub fn new(touch_buffer: Option<&mut [physx_sys::PxRaycastHit]>) -> Self {
+    pub fn new() -> Self {
+        unsafe {
+            Self {
+                obj: Owner::from_raw(
+                    create_raycast_buffer()
+                ),
+                phantom_user_callback: PhantomData,
+            }
+        }
+    }
+
+    pub fn with_user_callbacks(user_callback: &mut T, touch_buffer: Option<&mut [physx_sys::PxRaycastHit]>) -> Self {
         use std::convert::TryInto;
 
         let (buffer_ptr, buffer_len) = touch_buffer
             .map(|v| (v.as_mut_ptr(), v.len()))
             .unwrap_or((std::ptr::null_mut(), 0));
 
-        let buffer_len = buffer_len.try_into().unwrap(); // FIXME replace unwrap
+        // FIXME replace unwrap
+        let buffer_len = buffer_len.try_into().unwrap();
 
         unsafe {
             Self {
@@ -63,31 +95,55 @@ impl<T: RaycastCallback> PxRaycastCallback<T> {
                         Self::finalize_query,
                         buffer_ptr,
                         buffer_len,
-                        user_data as *mut _ as *mut c_void, // TODO we need to make sure this is dropped
+                        user_callback as *mut _ as *mut c_void,
                     )
                 ),
-                phantom_user_data: PhantomData,
+                phantom_user_callback: PhantomData,
             }
         }
+    }
+
+    pub fn get_blocking_hit(&self) -> Option<&physx_sys::PxRaycastHit> {
+        if let Some(obj) = &self.obj {
+            let callback = obj.as_ref();
+            if callback.hasBlock {
+                return Some(&callback.block);
+            }
+        }
+
+        None
+    }
+
+    pub fn get_touching_hits(&self) -> Option<&[physx_sys::PxRaycastHit]> {
+        if let Some(obj) = &self.obj {
+            let callback = obj.as_ref();
+            if callback.touches != std::ptr::null_mut() && callback.nbTouches > 0 {
+                unsafe {
+                    return Some(std::slice::from_raw_parts(callback.touches, callback.nbTouches as usize));
+                }
+            }
+        }
+
+        None
     }
 
     /// Must not panic.
     unsafe extern "C" fn process_touches(
         buffer: *const physx_sys::PxRaycastHit,
         num_hits: u32,
-        user_data: *mut c_void,
+        user_callback: *mut c_void,
     ) -> bool {
         std::panic::catch_unwind(|| {
-            (&mut *(user_data as *mut T)).process_touches(slice::from_raw_parts(buffer, num_hits as usize))
+            (&mut *(user_callback as *mut T)).process_touches(slice::from_raw_parts(buffer, num_hits as usize))
         }).unwrap_or(true)
     }
 
     /// Must not panic.
     unsafe extern "C" fn finalize_query(
-        user_data: *mut c_void,
+        user_callback: *mut c_void,
     ) {
         let _explicitly_ignored = std::panic::catch_unwind(|| {
-            (&mut *(user_data as *mut T)).finalize_query();
+            (&mut *(user_callback as *mut T)).finalize_query();
         });
     }
 }

--- a/physx/src/query.rs
+++ b/physx/src/query.rs
@@ -4,10 +4,6 @@
 
 //! Scene queries are used to perform tests against the actors and geometry held in a scene.
 
-#![warn(clippy::all)]
-#![allow(clippy::missing_safety_doc)]
-#![allow(deprecated)]
-
 use crate::{owner::Owner, traits::Class};
 use physx_sys::{
     create_overlap_buffer, create_overlap_callback, create_raycast_buffer, create_raycast_callback,

--- a/physx/src/query.rs
+++ b/physx/src/query.rs
@@ -7,7 +7,8 @@
 use crate::{owner::Owner, traits::Class};
 use physx_sys::{
     create_overlap_buffer, create_overlap_callback, create_raycast_buffer, create_raycast_callback,
-    create_sweep_buffer, create_sweep_callback, delete_raycast_callback,
+    create_sweep_buffer, create_sweep_callback, delete_overlap_callback, delete_raycast_callback,
+    delete_sweep_callback,
 };
 use std::ffi::c_void;
 use std::{marker::PhantomData, slice};
@@ -37,6 +38,8 @@ impl Into<physx_sys::PxQueryFilterData> for PxQueryFilterData {
     }
 }
 
+// RAYCAST CALLBACKS
+
 pub struct RaycastCallbackDefault;
 
 impl RaycastCallback for RaycastCallbackDefault {
@@ -64,8 +67,8 @@ impl<'buffer, T: RaycastCallback> Drop for PxRaycastCallback<'buffer, T> {
     }
 }
 
-impl<'buffer, T: RaycastCallback> PxRaycastCallback<'buffer, T> {
-    pub fn new() -> Self {
+impl<'buffer, T: RaycastCallback> Default for PxRaycastCallback<'buffer, T> {
+    fn default() -> Self {
         unsafe {
             Self {
                 obj: Owner::from_raw(create_raycast_buffer()),
@@ -74,7 +77,9 @@ impl<'buffer, T: RaycastCallback> PxRaycastCallback<'buffer, T> {
             }
         }
     }
+}
 
+impl<'buffer, T: RaycastCallback> PxRaycastCallback<'buffer, T> {
     pub fn with_user_callbacks(
         user_callback: &mut T,
         touch_buffer: Option<&'buffer mut [physx_sys::PxRaycastHit]>,
@@ -117,7 +122,7 @@ impl<'buffer, T: RaycastCallback> PxRaycastCallback<'buffer, T> {
     pub fn get_touching_hits(&self) -> Option<&[physx_sys::PxRaycastHit]> {
         if let Some(obj) = &self.obj {
             let callback = obj.as_ref();
-            if callback.touches != std::ptr::null_mut() && callback.nbTouches > 0 {
+            if !callback.touches.is_null() && callback.nbTouches > 0 {
                 unsafe {
                     return Some(std::slice::from_raw_parts(
                         callback.touches,
@@ -157,33 +162,250 @@ pub trait RaycastCallback {
     fn finalize_query(&mut self);
 }
 
-// /// A trait for creating custom raycast callbacks for PhysX.
-// pub unsafe trait RaycastCallback {
-//     unsafe fn get_raycast_hit(&mut self) -> Option<physx_sys::PxRaycastHit>;
-//     // TODO
-//     // unsafe fn get_raycast_touches(&mut self) -> Option<physx_sys::PxRaycastHit>;
+// SWEEP CALLBACKS
 
-//     /// # Safety
-//     /// Must not panic.
-//     unsafe extern "C" fn process_touches(
-//         buffer: *const physx_sys::PxRaycastHit,
-//         num_hits: u32,
-//         user_data: *const c_void,
-//     ) -> bool;
+pub struct SweepCallbackDefault;
 
-//     /// # Safety
-//     /// Must not panic.
-//     unsafe extern "C" fn finalize_query(user_data: *const c_void);
+impl SweepCallback for SweepCallbackDefault {
+    fn process_touches(&mut self, _touches: &[physx_sys::PxSweepHit]) -> bool {
+        unimplemented!()
+    }
+    fn finalize_query(&mut self) {
+        unimplemented!()
+    }
+}
 
-//     /// # Safety
-//     /// Do not override this method.
-//     unsafe fn into_px(&mut self) -> *mut physx_sys::PxRaycastCallback {
-//         create_raycast_callback(
-//             Self::process_touches,
-//             Self::finalize_query,
-//             std::ptr::null_mut(),
-//             0,
-//             Box::into_raw(Box::new(self)) as *mut c_void,
-//         )
-//     }
-// }
+pub struct PxSweepCallback<'buffer, T: SweepCallback> {
+    pub(crate) obj: Option<Owner<physx_sys::PxSweepCallback>>,
+    phantom_touch_buffer: PhantomData<Option<&'buffer mut [physx_sys::PxSweepHit]>>,
+    phantom_user_callback: PhantomData<T>,
+}
+
+impl<'buffer, T: SweepCallback> Drop for PxSweepCallback<'buffer, T> {
+    fn drop(&mut self) {
+        if let Some(obj) = &mut self.obj {
+            unsafe {
+                delete_sweep_callback(obj.as_mut_ptr());
+            }
+        }
+    }
+}
+
+impl<'buffer, T: SweepCallback> Default for PxSweepCallback<'buffer, T> {
+    fn default() -> Self {
+        unsafe {
+            Self {
+                obj: Owner::from_raw(create_sweep_buffer()),
+                phantom_touch_buffer: PhantomData,
+                phantom_user_callback: PhantomData,
+            }
+        }
+    }
+}
+
+impl<'buffer, T: SweepCallback> PxSweepCallback<'buffer, T> {
+    pub fn with_user_callbacks(
+        user_callback: &mut T,
+        touch_buffer: Option<&'buffer mut [physx_sys::PxSweepHit]>,
+    ) -> Self {
+        use std::convert::TryInto;
+
+        let (buffer_ptr, buffer_len) = touch_buffer
+            .map(|v| (v.as_mut_ptr(), v.len()))
+            .unwrap_or((std::ptr::null_mut(), 0));
+
+        // FIXME replace unwrap
+        let buffer_len = buffer_len.try_into().unwrap();
+
+        unsafe {
+            Self {
+                obj: Owner::from_raw(create_sweep_callback(
+                    Self::process_touches,
+                    Self::finalize_query,
+                    buffer_ptr,
+                    buffer_len,
+                    user_callback as *mut _ as *mut c_void,
+                )),
+                phantom_touch_buffer: PhantomData,
+                phantom_user_callback: PhantomData,
+            }
+        }
+    }
+
+    pub fn get_blocking_hit(&self) -> Option<&physx_sys::PxSweepHit> {
+        if let Some(obj) = &self.obj {
+            let callback = obj.as_ref();
+            if callback.hasBlock {
+                return Some(&callback.block);
+            }
+        }
+
+        None
+    }
+
+    pub fn get_touching_hits(&self) -> Option<&[physx_sys::PxSweepHit]> {
+        if let Some(obj) = &self.obj {
+            let callback = obj.as_ref();
+            if !callback.touches.is_null() && callback.nbTouches > 0 {
+                unsafe {
+                    return Some(std::slice::from_raw_parts(
+                        callback.touches,
+                        callback.nbTouches as usize,
+                    ));
+                }
+            }
+        }
+
+        None
+    }
+
+    /// Must not panic.
+    unsafe extern "C" fn process_touches(
+        buffer: *const physx_sys::PxSweepHit,
+        num_hits: u32,
+        user_callback: *mut c_void,
+    ) -> bool {
+        std::panic::catch_unwind(|| {
+            (&mut *(user_callback as *mut T))
+                .process_touches(slice::from_raw_parts(buffer, num_hits as usize))
+        })
+        .unwrap_or(true)
+    }
+
+    /// Must not panic.
+    unsafe extern "C" fn finalize_query(user_callback: *mut c_void) {
+        let _explicitly_ignored = std::panic::catch_unwind(|| {
+            (&mut *(user_callback as *mut T)).finalize_query();
+        });
+    }
+}
+
+/// A safe wrapper around sweep PhysX callbacks
+pub trait SweepCallback {
+    fn process_touches(&mut self, touches: &[physx_sys::PxSweepHit]) -> bool;
+    fn finalize_query(&mut self);
+}
+
+// OVERLAP CALLBACKS
+
+pub struct OverlapCallbackDefault;
+
+impl OverlapCallback for OverlapCallbackDefault {
+    fn process_touches(&mut self, _touches: &[physx_sys::PxOverlapHit]) -> bool {
+        unimplemented!()
+    }
+    fn finalize_query(&mut self) {
+        unimplemented!()
+    }
+}
+
+pub struct PxOverlapCallback<'buffer, T: OverlapCallback> {
+    pub(crate) obj: Option<Owner<physx_sys::PxOverlapCallback>>,
+    phantom_touch_buffer: PhantomData<Option<&'buffer mut [physx_sys::PxOverlapHit]>>,
+    phantom_user_callback: PhantomData<T>,
+}
+
+impl<'buffer, T: OverlapCallback> Drop for PxOverlapCallback<'buffer, T> {
+    fn drop(&mut self) {
+        if let Some(obj) = &mut self.obj {
+            unsafe {
+                delete_overlap_callback(obj.as_mut_ptr());
+            }
+        }
+    }
+}
+
+impl<'buffer, T: OverlapCallback> Default for PxOverlapCallback<'buffer, T> {
+    fn default() -> Self {
+        unsafe {
+            Self {
+                obj: Owner::from_raw(create_overlap_buffer()),
+                phantom_touch_buffer: PhantomData,
+                phantom_user_callback: PhantomData,
+            }
+        }
+    }
+}
+
+impl<'buffer, T: OverlapCallback> PxOverlapCallback<'buffer, T> {
+    pub fn with_user_callbacks(
+        user_callback: &mut T,
+        touch_buffer: Option<&'buffer mut [physx_sys::PxOverlapHit]>,
+    ) -> Self {
+        use std::convert::TryInto;
+
+        let (buffer_ptr, buffer_len) = touch_buffer
+            .map(|v| (v.as_mut_ptr(), v.len()))
+            .unwrap_or((std::ptr::null_mut(), 0));
+
+        // FIXME replace unwrap
+        let buffer_len = buffer_len.try_into().unwrap();
+
+        unsafe {
+            Self {
+                obj: Owner::from_raw(create_overlap_callback(
+                    Self::process_touches,
+                    Self::finalize_query,
+                    buffer_ptr,
+                    buffer_len,
+                    user_callback as *mut _ as *mut c_void,
+                )),
+                phantom_touch_buffer: PhantomData,
+                phantom_user_callback: PhantomData,
+            }
+        }
+    }
+
+    pub fn get_blocking_hit(&self) -> Option<&physx_sys::PxOverlapHit> {
+        if let Some(obj) = &self.obj {
+            let callback = obj.as_ref();
+            if callback.hasBlock {
+                return Some(&callback.block);
+            }
+        }
+
+        None
+    }
+
+    pub fn get_touching_hits(&self) -> Option<&[physx_sys::PxOverlapHit]> {
+        if let Some(obj) = &self.obj {
+            let callback = obj.as_ref();
+            if !callback.touches.is_null() && callback.nbTouches > 0 {
+                unsafe {
+                    return Some(std::slice::from_raw_parts(
+                        callback.touches,
+                        callback.nbTouches as usize,
+                    ));
+                }
+            }
+        }
+
+        None
+    }
+
+    /// Must not panic.
+    unsafe extern "C" fn process_touches(
+        buffer: *const physx_sys::PxOverlapHit,
+        num_hits: u32,
+        user_callback: *mut c_void,
+    ) -> bool {
+        std::panic::catch_unwind(|| {
+            (&mut *(user_callback as *mut T))
+                .process_touches(slice::from_raw_parts(buffer, num_hits as usize))
+        })
+        .unwrap_or(true)
+    }
+
+    /// Must not panic.
+    unsafe extern "C" fn finalize_query(user_callback: *mut c_void) {
+        let _explicitly_ignored = std::panic::catch_unwind(|| {
+            (&mut *(user_callback as *mut T)).finalize_query();
+        });
+    }
+}
+
+/// A safe wrapper around overlap PhysX callbacks
+pub trait OverlapCallback {
+    fn process_touches(&mut self, touches: &[physx_sys::PxOverlapHit]) -> bool;
+    fn finalize_query(&mut self);
+}

--- a/physx/src/query.rs
+++ b/physx/src/query.rs
@@ -1,6 +1,6 @@
-// Author: Tom Olsson <tom.olsson@embark-studios.com>
+// Author: Nick Caplinger <the.nick.caplinger@gmail.com>
 // Copyright © 2020, Embark Studios, all rights reserved.
-// Created: 9 December 2020
+// Created: 14 December 2020
 
 //! Scene queries are used to perform tests against the actors and geometry held in a scene.
 

--- a/physx/src/query.rs
+++ b/physx/src/query.rs
@@ -96,6 +96,8 @@ pub unsafe trait RaycastCallback: Sized {
         create_raycast_callback(
             Self::process_touches,
             Self::finalize_query,
+            std::ptr::null_mut(),
+            0,
             Box::into_raw(Box::new(self)) as *mut c_void,
         )
     }
@@ -161,6 +163,8 @@ pub unsafe trait SweepCallback: Sized {
         create_sweep_callback(
             Self::process_touches,
             Self::finalize_query,
+            std::ptr::null_mut(),
+            0,
             Box::into_raw(Box::new(self)) as *mut c_void,
         )
     }
@@ -226,6 +230,8 @@ pub unsafe trait OverlapCallback: Sized {
         create_overlap_callback(
             Self::process_touches,
             Self::finalize_query,
+            std::ptr::null_mut(),
+            0,
             Box::into_raw(Box::new(self)) as *mut c_void,
         )
     }

--- a/physx/src/query.rs
+++ b/physx/src/query.rs
@@ -1,0 +1,290 @@
+// Author: Tom Olsson <tom.olsson@embark-studios.com>
+// Copyright © 2020, Embark Studios, all rights reserved.
+// Created: 9 December 2020
+
+//! Scene queries are used to perform tests against the actors and geometry held in a scene.
+
+#![warn(clippy::all)]
+#![allow(clippy::missing_safety_doc)]
+#![allow(deprecated)]
+
+use crate::{owner::Owner, traits::Class};
+use physx_sys::{
+    create_overlap_buffer, create_overlap_callback, create_raycast_buffer, create_raycast_callback,
+    create_sweep_buffer, create_sweep_callback,
+};
+use std::ffi::c_void;
+
+#[repr(transparent)]
+pub struct PxQueryFilterData {
+    pub(crate) obj: physx_sys::PxQueryFilterData,
+}
+
+crate::DeriveClassForNewType!(PxQueryFilterData: PxQueryFilterData);
+
+impl Default for PxQueryFilterData {
+    fn default() -> Self {
+        unsafe { physx_sys::PxQueryFilterData_new().into() }
+    }
+}
+
+impl From<physx_sys::PxQueryFilterData> for PxQueryFilterData {
+    fn from(data: physx_sys::PxQueryFilterData) -> Self {
+        PxQueryFilterData { obj: data }
+    }
+}
+
+impl Into<physx_sys::PxQueryFilterData> for PxQueryFilterData {
+    fn into(self) -> physx_sys::PxQueryFilterData {
+        self.obj
+    }
+}
+
+#[repr(transparent)]
+pub struct PxRaycastCallback {
+    pub obj: Owner<physx_sys::PxRaycastCallback>,
+}
+
+#[repr(transparent)]
+pub struct PxRaycastBuffer(PxRaycastCallback);
+
+unsafe impl Class<PxRaycastCallback> for PxRaycastBuffer {
+    fn as_ptr(&self) -> *const PxRaycastCallback {
+        self.0.obj.as_ptr() as *const _ as *const _
+    }
+    fn as_mut_ptr(&mut self) -> *mut PxRaycastCallback {
+        self.0.obj.as_mut_ptr() as *mut _ as *mut _
+    }
+}
+
+unsafe impl Class<physx_sys::PxRaycastCallback> for PxRaycastBuffer {
+    fn as_ptr(&self) -> *const physx_sys::PxRaycastCallback {
+        self.0.obj.as_ptr() as *const _ as *const _
+    }
+    fn as_mut_ptr(&mut self) -> *mut physx_sys::PxRaycastCallback {
+        self.0.obj.as_mut_ptr() as *mut _ as *mut _
+    }
+}
+
+unsafe impl RaycastCallback for PxRaycastBuffer {
+    unsafe fn new() -> Self {
+        Self(PxRaycastCallback {
+            obj: Owner::from_raw(create_raycast_buffer()).unwrap(),
+        })
+    }
+
+    unsafe fn get_raycast_hit(&mut self) -> Option<physx_sys::PxRaycastHit> {
+        Some(self.0.obj.block)
+    }
+
+    unsafe extern "C" fn process_touches(
+        _buffer: *const physx_sys::PxRaycastHit,
+        _num_hits: u32,
+        _user_data: *const c_void,
+    ) -> bool {
+        // Unused by this impl
+        false
+    }
+
+    unsafe extern "C" fn finalize_query(_user_data: *const c_void) {
+        // Unused by this impl
+    }
+
+    unsafe fn into_px(&mut self) -> *mut physx_sys::PxRaycastCallback {
+        self.0.obj.as_mut_ptr()
+    }
+}
+
+/// A trait for creating custom raycast callbacks for PhysX.
+pub unsafe trait RaycastCallback: Sized {
+    unsafe fn new() -> Self;
+    unsafe fn get_raycast_hit(&mut self) -> Option<physx_sys::PxRaycastHit>;
+
+    /// # Safety
+    /// Must not panic.
+    unsafe extern "C" fn process_touches(
+        buffer: *const physx_sys::PxRaycastHit,
+        num_hits: u32,
+        user_data: *const c_void,
+    ) -> bool;
+
+    /// # Safety
+    /// Must not panic.
+    unsafe extern "C" fn finalize_query(user_data: *const c_void);
+
+    /// # Safety
+    /// Do not override this method.
+    unsafe fn into_px(&mut self) -> *mut physx_sys::PxRaycastCallback {
+        create_raycast_callback(
+            Self::process_touches,
+            Self::finalize_query,
+            Box::into_raw(Box::new(self)) as *mut c_void,
+        )
+    }
+}
+
+#[repr(transparent)]
+pub struct PxSweepCallback {
+    pub obj: Owner<physx_sys::PxSweepCallback>,
+}
+
+#[repr(transparent)]
+pub struct PxSweepBuffer(PxSweepCallback);
+
+unsafe impl Class<PxSweepCallback> for PxSweepBuffer {
+    fn as_ptr(&self) -> *const PxSweepCallback {
+        self.0.obj.as_ptr() as *const _ as *const _
+    }
+    fn as_mut_ptr(&mut self) -> *mut PxSweepCallback {
+        self.0.obj.as_mut_ptr() as *mut _ as *mut _
+    }
+}
+
+unsafe impl Class<physx_sys::PxSweepCallback> for PxSweepBuffer {
+    fn as_ptr(&self) -> *const physx_sys::PxSweepCallback {
+        self.0.obj.as_ptr() as *const _ as *const _
+    }
+    fn as_mut_ptr(&mut self) -> *mut physx_sys::PxSweepCallback {
+        self.0.obj.as_mut_ptr() as *mut _ as *mut _
+    }
+}
+
+unsafe impl SweepCallback for PxSweepBuffer {
+    unsafe fn new() -> Self {
+        Self(PxSweepCallback {
+            obj: Owner::from_raw(create_sweep_buffer()).unwrap(),
+        })
+    }
+
+    unsafe fn get_sweep_hit(&mut self) -> Option<physx_sys::PxSweepHit> {
+        Some(self.0.obj.block)
+    }
+
+    unsafe extern "C" fn process_touches(
+        _buffer: *const physx_sys::PxSweepHit,
+        _num_hits: u32,
+        _user_data: *const c_void,
+    ) -> bool {
+        // Unused by this impl
+        false
+    }
+
+    unsafe extern "C" fn finalize_query(_user_data: *const c_void) {
+        // Unused by this impl
+    }
+
+    unsafe fn into_px(&mut self) -> *mut physx_sys::PxSweepCallback {
+        self.0.obj.as_mut_ptr()
+    }
+}
+
+/// A trait for creating custom sweep callbacks for PhysX.
+pub unsafe trait SweepCallback: Sized {
+    unsafe fn new() -> Self;
+    unsafe fn get_sweep_hit(&mut self) -> Option<physx_sys::PxSweepHit>;
+
+    /// # Safety
+    /// Must not panic.
+    unsafe extern "C" fn process_touches(
+        buffer: *const physx_sys::PxSweepHit,
+        num_hits: u32,
+        user_data: *const c_void,
+    ) -> bool;
+
+    /// # Safety
+    /// Must not panic.
+    unsafe extern "C" fn finalize_query(user_data: *const c_void);
+
+    /// # Safety
+    /// Do not override this method.
+    unsafe fn into_px(&mut self) -> *mut physx_sys::PxSweepCallback {
+        create_sweep_callback(
+            Self::process_touches,
+            Self::finalize_query,
+            Box::into_raw(Box::new(self)) as *mut c_void,
+        )
+    }
+}
+
+#[repr(transparent)]
+pub struct PxOverlapCallback {
+    pub obj: Owner<physx_sys::PxOverlapCallback>,
+}
+
+#[repr(transparent)]
+pub struct PxOverlapBuffer(PxOverlapCallback);
+
+unsafe impl Class<PxOverlapCallback> for PxOverlapBuffer {
+    fn as_ptr(&self) -> *const PxOverlapCallback {
+        self.0.obj.as_ptr() as *const _ as *const _
+    }
+    fn as_mut_ptr(&mut self) -> *mut PxOverlapCallback {
+        self.0.obj.as_mut_ptr() as *mut _ as *mut _
+    }
+}
+
+unsafe impl Class<physx_sys::PxOverlapCallback> for PxOverlapBuffer {
+    fn as_ptr(&self) -> *const physx_sys::PxOverlapCallback {
+        self.0.obj.as_ptr() as *const _ as *const _
+    }
+    fn as_mut_ptr(&mut self) -> *mut physx_sys::PxOverlapCallback {
+        self.0.obj.as_mut_ptr() as *mut _ as *mut _
+    }
+}
+
+unsafe impl OverlapCallback for PxOverlapBuffer {
+    unsafe fn new() -> Self {
+        Self(PxOverlapCallback {
+            obj: Owner::from_raw(create_overlap_buffer()).unwrap(),
+        })
+    }
+
+    unsafe fn get_overlap_hit(&mut self) -> Option<physx_sys::PxOverlapHit> {
+        Some(self.0.obj.block)
+    }
+
+    unsafe extern "C" fn process_touches(
+        _buffer: *const physx_sys::PxOverlapHit,
+        _num_hits: u32,
+        _user_data: *const c_void,
+    ) -> bool {
+        // Unused by this impl
+        false
+    }
+
+    unsafe extern "C" fn finalize_query(_user_data: *const c_void) {
+        // Unused by this impl
+    }
+
+    unsafe fn into_px(&mut self) -> *mut physx_sys::PxOverlapCallback {
+        self.0.obj.as_mut_ptr()
+    }
+}
+
+/// A trait for creating custom overlap callbacks for PhysX.
+pub unsafe trait OverlapCallback: Sized {
+    unsafe fn new() -> Self;
+    unsafe fn get_overlap_hit(&mut self) -> Option<physx_sys::PxOverlapHit>;
+
+    /// # Safety
+    /// Must not panic.
+    unsafe extern "C" fn process_touches(
+        buffer: *const physx_sys::PxOverlapHit,
+        num_hits: u32,
+        user_data: *const c_void,
+    ) -> bool;
+
+    /// # Safety
+    /// Must not panic.
+    unsafe extern "C" fn finalize_query(user_data: *const c_void);
+
+    /// # Safety
+    /// Do not override this method.
+    unsafe fn into_px(&mut self) -> *mut physx_sys::PxOverlapCallback {
+        create_overlap_callback(
+            Self::process_touches,
+            Self::finalize_query,
+            Box::into_raw(Box::new(self)) as *mut c_void,
+        )
+    }
+}

--- a/physx/src/query.rs
+++ b/physx/src/query.rs
@@ -71,20 +71,24 @@ impl<T: RaycastCallback> PxRaycastCallback<T> {
         }
     }
 
+    /// Must not panic.
     unsafe extern "C" fn process_touches(
         buffer: *const physx_sys::PxRaycastHit,
         num_hits: u32,
         user_data: *mut c_void,
     ) -> bool {
-        // TODO catch_unwind
-        (&mut *(user_data as *mut T)).process_touches(slice::from_raw_parts(buffer, num_hits as usize))
+        std::panic::catch_unwind(|| {
+            (&mut *(user_data as *mut T)).process_touches(slice::from_raw_parts(buffer, num_hits as usize))
+        }).unwrap_or(true)
     }
 
+    /// Must not panic.
     unsafe extern "C" fn finalize_query(
         user_data: *mut c_void,
     ) {
-        // TODO catch_unwind
-        (&mut *(user_data as *mut T)).finalize_query();
+        let _explicitly_ignored = std::panic::catch_unwind(|| {
+            (&mut *(user_data as *mut T)).finalize_query();
+        });
     }
 }
 

--- a/physx/src/query.rs
+++ b/physx/src/query.rs
@@ -44,24 +44,6 @@ pub struct PxRaycastCallback {
 #[repr(transparent)]
 pub struct PxRaycastBuffer(PxRaycastCallback);
 
-unsafe impl Class<PxRaycastCallback> for PxRaycastBuffer {
-    fn as_ptr(&self) -> *const PxRaycastCallback {
-        self.0.obj.as_ptr() as *const _ as *const _
-    }
-    fn as_mut_ptr(&mut self) -> *mut PxRaycastCallback {
-        self.0.obj.as_mut_ptr() as *mut _ as *mut _
-    }
-}
-
-unsafe impl Class<physx_sys::PxRaycastCallback> for PxRaycastBuffer {
-    fn as_ptr(&self) -> *const physx_sys::PxRaycastCallback {
-        self.0.obj.as_ptr() as *const _ as *const _
-    }
-    fn as_mut_ptr(&mut self) -> *mut physx_sys::PxRaycastCallback {
-        self.0.obj.as_mut_ptr() as *mut _ as *mut _
-    }
-}
-
 unsafe impl RaycastCallback for PxRaycastBuffer {
     unsafe fn new() -> Self {
         Self(PxRaycastCallback {
@@ -127,24 +109,6 @@ pub struct PxSweepCallback {
 #[repr(transparent)]
 pub struct PxSweepBuffer(PxSweepCallback);
 
-unsafe impl Class<PxSweepCallback> for PxSweepBuffer {
-    fn as_ptr(&self) -> *const PxSweepCallback {
-        self.0.obj.as_ptr() as *const _ as *const _
-    }
-    fn as_mut_ptr(&mut self) -> *mut PxSweepCallback {
-        self.0.obj.as_mut_ptr() as *mut _ as *mut _
-    }
-}
-
-unsafe impl Class<physx_sys::PxSweepCallback> for PxSweepBuffer {
-    fn as_ptr(&self) -> *const physx_sys::PxSweepCallback {
-        self.0.obj.as_ptr() as *const _ as *const _
-    }
-    fn as_mut_ptr(&mut self) -> *mut physx_sys::PxSweepCallback {
-        self.0.obj.as_mut_ptr() as *mut _ as *mut _
-    }
-}
-
 unsafe impl SweepCallback for PxSweepBuffer {
     unsafe fn new() -> Self {
         Self(PxSweepCallback {
@@ -209,24 +173,6 @@ pub struct PxOverlapCallback {
 
 #[repr(transparent)]
 pub struct PxOverlapBuffer(PxOverlapCallback);
-
-unsafe impl Class<PxOverlapCallback> for PxOverlapBuffer {
-    fn as_ptr(&self) -> *const PxOverlapCallback {
-        self.0.obj.as_ptr() as *const _ as *const _
-    }
-    fn as_mut_ptr(&mut self) -> *mut PxOverlapCallback {
-        self.0.obj.as_mut_ptr() as *mut _ as *mut _
-    }
-}
-
-unsafe impl Class<physx_sys::PxOverlapCallback> for PxOverlapBuffer {
-    fn as_ptr(&self) -> *const physx_sys::PxOverlapCallback {
-        self.0.obj.as_ptr() as *const _ as *const _
-    }
-    fn as_mut_ptr(&mut self) -> *mut physx_sys::PxOverlapCallback {
-        self.0.obj.as_mut_ptr() as *mut _ as *mut _
-    }
-}
 
 unsafe impl OverlapCallback for PxOverlapBuffer {
     unsafe fn new() -> Self {

--- a/physx/src/scene.rs
+++ b/physx/src/scene.rs
@@ -24,7 +24,7 @@ use crate::{
     math::{PxTransform, PxVec3},
     owner::Owner,
     pruning_structure::PruningStructure,
-    query::{OverlapCallback, PxQueryFilterData, RaycastCallback, SweepCallback},
+    query::{PxQueryFilterData, RaycastCallback, PxRaycastCallback},
     rigid_actor::RigidActor,
     rigid_dynamic::RigidDynamic,
     rigid_static::RigidStatic,
@@ -643,12 +643,13 @@ pub trait Scene: Class<physx_sys::PxScene> + UserData {
     ///
     /// [src]: (https://gameworksdocs.nvidia.com/PhysX/4.1/documentation/physxapi/files/classPxScene.html#a7d7dcd877cee092f8b57c67d79982b50)
     #[allow(clippy::too_many_arguments)]
-    fn raycast(
+    fn raycast<T: RaycastCallback>(
         &self,
         origin: &PxVec3,
         unit_dir: &PxVec3,
         distance: f32,
-        hit_callback: &mut impl RaycastCallback,
+        // hit_callback: &mut impl RaycastCallback,
+        hit_callback: &mut PxRaycastCallback<T>,
         hit_flags: HitFlags,
         filter_data: &PxQueryFilterData,
         filter_callback: Option<&mut PxQueryFilterCallback>,
@@ -661,14 +662,12 @@ pub trait Scene: Class<physx_sys::PxScene> + UserData {
         let cache = cache.map_or(std::ptr::null::<PxQueryCache>(), |v| v as *const _);
 
         unsafe {
-            let hit_callback = hit_callback.into_px();
-
             PxScene_raycast(
                 self.as_ptr(),
                 origin.as_ptr(),
                 unit_dir.as_ptr(),
                 distance,
-                hit_callback,
+                hit_callback.obj.as_mut().unwrap().as_mut_ptr(), // FIXME don't just unwrap
                 hit_flags.into_px(),
                 &filter_data.obj,
                 filter_callback,
@@ -677,82 +676,82 @@ pub trait Scene: Class<physx_sys::PxScene> + UserData {
         }
     }
 
-    /// Sweeps a shape across the scene, reporting any hit objects via the [`SweepCallback`] trait passed into `hit_callback`.
-    /// For simple usage, passing in [`PxSweepBuffer`] will suffice.
-    /// Users can also provide a custom implementation of [`SweepCallback`] in cases where allocating a single buffer to store
-    /// hits is prohibitively expensive.
-    /// Returns true if the sweep hit an actor.
-    /// See the [PhysX documentation on `sweep`][src] for more details.
-    ///
-    /// [src]: (https://gameworksdocs.nvidia.com/PhysX/4.1/documentation/physxapi/files/classPxScene.html#a9b07b2a98e64105a06e97ffaeba2a63d)
-    #[allow(clippy::too_many_arguments)]
-    fn sweep(
-        &self,
-        geometry: &impl Geometry,
-        pose: &PxTransform,
-        direction: &PxVec3,
-        distance: f32,
-        hit_callback: &mut impl SweepCallback,
-        hit_flags: HitFlags,
-        filter_data: &PxQueryFilterData,
-        filter_callback: Option<&mut PxQueryFilterCallback>,
-        cache: Option<&PxQueryCache>,
-        inflation: f32,
-    ) -> bool {
-        let filter_callback = filter_callback
-            .map(|v| v as *mut _)
-            .unwrap_or(std::ptr::null_mut());
-        let cache = cache.map(|v| v as *const _).unwrap_or(std::ptr::null());
-        unsafe {
-            let hit_callback = hit_callback.into_px();
-            PxScene_sweep(
-                self.as_ptr(),
-                geometry.as_ptr(),
-                pose.as_ptr(),
-                direction.as_ptr(),
-                distance,
-                hit_callback,
-                hit_flags.into_px(),
-                &filter_data.obj,
-                filter_callback,
-                cache,
-                inflation,
-            )
-        }
-    }
+    // /// Sweeps a shape across the scene, reporting any hit objects via the [`SweepCallback`] trait passed into `hit_callback`.
+    // /// For simple usage, passing in [`PxSweepBuffer`] will suffice.
+    // /// Users can also provide a custom implementation of [`SweepCallback`] in cases where allocating a single buffer to store
+    // /// hits is prohibitively expensive.
+    // /// Returns true if the sweep hit an actor.
+    // /// See the [PhysX documentation on `sweep`][src] for more details.
+    // ///
+    // /// [src]: (https://gameworksdocs.nvidia.com/PhysX/4.1/documentation/physxapi/files/classPxScene.html#a9b07b2a98e64105a06e97ffaeba2a63d)
+    // #[allow(clippy::too_many_arguments)]
+    // fn sweep(
+    //     &self,
+    //     geometry: &impl Geometry,
+    //     pose: &PxTransform,
+    //     direction: &PxVec3,
+    //     distance: f32,
+    //     hit_callback: &mut impl SweepCallback,
+    //     hit_flags: HitFlags,
+    //     filter_data: &PxQueryFilterData,
+    //     filter_callback: Option<&mut PxQueryFilterCallback>,
+    //     cache: Option<&PxQueryCache>,
+    //     inflation: f32,
+    // ) -> bool {
+    //     let filter_callback = filter_callback
+    //         .map(|v| v as *mut _)
+    //         .unwrap_or(std::ptr::null_mut());
+    //     let cache = cache.map(|v| v as *const _).unwrap_or(std::ptr::null());
+    //     unsafe {
+    //         let hit_callback = hit_callback.into_px();
+    //         PxScene_sweep(
+    //             self.as_ptr(),
+    //             geometry.as_ptr(),
+    //             pose.as_ptr(),
+    //             direction.as_ptr(),
+    //             distance,
+    //             hit_callback,
+    //             hit_flags.into_px(),
+    //             &filter_data.obj,
+    //             filter_callback,
+    //             cache,
+    //             inflation,
+    //         )
+    //     }
+    // }
 
-    /// Reports any objects overlapping with the given shape via the [`SweepCallback`] trait passed into `hit_callback`.
-    /// For simple usage, passing in [`PxOverlapBuffer`] will suffice.
-    /// Users can also provide a custom implementation of [`OverlapCallback`] in cases where allocating a single buffer to store
-    /// hits is prohibitively expensive.
-    /// Returns true if the overlap hit an actor.
-    /// See the [PhysX documentation on `overlap`][src] for more details.
-    ///
-    /// [src]: (https://gameworksdocs.nvidia.com/PhysX/4.1/documentation/physxapi/files/classPxScene.html#a31d09c0e967f9806a1f0d5df78dfc996)
-    fn overlap(
-        &self,
-        geometry: &impl Geometry,
-        pose: &PxTransform,
-        hit_callback: &mut impl OverlapCallback,
-        filter_data: &PxQueryFilterData,
-        filter_callback: Option<&mut PxQueryFilterCallback>,
-    ) -> bool {
-        let filter_callback = filter_callback
-            .map_or(std::ptr::null_mut::<PxQueryFilterCallback>(), |v| {
-                v as *mut _
-            });
-        unsafe {
-            let hit_callback = hit_callback.into_px();
-            PxScene_overlap(
-                self.as_ptr(),
-                geometry.as_ptr(),
-                pose.as_ptr(),
-                hit_callback,
-                &filter_data.obj,
-                filter_callback,
-            )
-        }
-    }
+    // /// Reports any objects overlapping with the given shape via the [`SweepCallback`] trait passed into `hit_callback`.
+    // /// For simple usage, passing in [`PxOverlapBuffer`] will suffice.
+    // /// Users can also provide a custom implementation of [`OverlapCallback`] in cases where allocating a single buffer to store
+    // /// hits is prohibitively expensive.
+    // /// Returns true if the overlap hit an actor.
+    // /// See the [PhysX documentation on `overlap`][src] for more details.
+    // ///
+    // /// [src]: (https://gameworksdocs.nvidia.com/PhysX/4.1/documentation/physxapi/files/classPxScene.html#a31d09c0e967f9806a1f0d5df78dfc996)
+    // fn overlap(
+    //     &self,
+    //     geometry: &impl Geometry,
+    //     pose: &PxTransform,
+    //     hit_callback: &mut impl OverlapCallback,
+    //     filter_data: &PxQueryFilterData,
+    //     filter_callback: Option<&mut PxQueryFilterCallback>,
+    // ) -> bool {
+    //     let filter_callback = filter_callback
+    //         .map_or(std::ptr::null_mut::<PxQueryFilterCallback>(), |v| {
+    //             v as *mut _
+    //         });
+    //     unsafe {
+    //         let hit_callback = hit_callback.into_px();
+    //         PxScene_overlap(
+    //             self.as_ptr(),
+    //             geometry.as_ptr(),
+    //             pose.as_ptr(),
+    //             hit_callback,
+    //             &filter_data.obj,
+    //             filter_callback,
+    //         )
+    //     }
+    // }
 
     ////////////////////////////////////////////////////////////////////////////////
     // Bulk Getters

--- a/physx/src/scene.rs
+++ b/physx/src/scene.rs
@@ -700,10 +700,9 @@ pub trait Scene: Class<physx_sys::PxScene> + UserData {
         inflation: f32,
     ) -> bool {
         let filter_callback = filter_callback
-            .map_or(std::ptr::null_mut::<PxQueryFilterCallback>(), |v| {
-                v as *mut _
-            });
-        let cache = cache.map_or(std::ptr::null::<PxQueryCache>(), |v| v as *const _);
+            .map(|v| v as *mut _)
+            .unwrap_or(std::ptr::null_mut());
+        let cache = cache.map(|v| v as *const _).unwrap_or(std::ptr::null());
         unsafe {
             let hit_callback = hit_callback.into_px();
             PxScene_sweep(

--- a/physx/src/scene.rs
+++ b/physx/src/scene.rs
@@ -648,7 +648,6 @@ pub trait Scene: Class<physx_sys::PxScene> + UserData {
         origin: &PxVec3,
         unit_dir: &PxVec3,
         distance: f32,
-        // hit_callback: &mut impl RaycastCallback,
         hit_callback: &mut PxRaycastCallback<T>,
         hit_flags: HitFlags,
         filter_data: &PxQueryFilterData,
@@ -667,7 +666,7 @@ pub trait Scene: Class<physx_sys::PxScene> + UserData {
                 origin.as_ptr(),
                 unit_dir.as_ptr(),
                 distance,
-                hit_callback.obj.as_mut().unwrap().as_mut_ptr(), // FIXME don't just unwrap
+                hit_callback.obj.as_mut().unwrap().as_mut_ptr(),
                 hit_flags.into_px(),
                 &filter_data.obj,
                 filter_callback,

--- a/physx/src/scene.rs
+++ b/physx/src/scene.rs
@@ -24,7 +24,7 @@ use crate::{
     math::{PxTransform, PxVec3},
     owner::Owner,
     pruning_structure::PruningStructure,
-    query::{PxQueryFilterData, RaycastCallback, PxRaycastCallback},
+    query::{PxQueryFilterData, PxRaycastCallback, RaycastCallback},
     rigid_actor::RigidActor,
     rigid_dynamic::RigidDynamic,
     rigid_static::RigidStatic,

--- a/physx/src/scene.rs
+++ b/physx/src/scene.rs
@@ -643,12 +643,12 @@ pub trait Scene: Class<physx_sys::PxScene> + UserData {
     ///
     /// [src]: (https://gameworksdocs.nvidia.com/PhysX/4.1/documentation/physxapi/files/classPxScene.html#a7d7dcd877cee092f8b57c67d79982b50)
     #[allow(clippy::too_many_arguments)]
-    fn raycast<T: RaycastCallback>(
+    fn raycast<'buffer, T: RaycastCallback>(
         &self,
         origin: &PxVec3,
         unit_dir: &PxVec3,
         distance: f32,
-        hit_callback: &mut PxRaycastCallback<T>,
+        hit_callback: &mut PxRaycastCallback<'buffer, T>,
         hit_flags: HitFlags,
         filter_data: &PxQueryFilterData,
         filter_callback: Option<&mut PxQueryFilterCallback>,

--- a/physx/src/traits/class.rs
+++ b/physx/src/traits/class.rs
@@ -20,8 +20,10 @@ use physx_sys::{
     PxHeightField,
     PxJoint,
     PxMaterial,
+    PxOverlapCallback,
     PxPrismaticJoint,
     PxPruningStructure,
+    PxRaycastCallback,
     PxRevoluteJoint,
     PxRigidActor,
     PxRigidBody,
@@ -29,6 +31,7 @@ use physx_sys::{
     PxRigidStatic,
     PxShape,
     PxSphericalJoint,
+    PxSweepCallback,
     PxTriangleMesh,
     PxVehicleDrive,
     PxVehicleDrive4W,
@@ -195,6 +198,10 @@ DeriveClass!(PxVec3);
 DeriveClass!(PxExtendedVec3);
 DeriveClass!(PxMeshScale);
 DeriveClass!(PxBounds3);
+
+DeriveClass!(PxRaycastCallback);
+DeriveClass!(PxSweepCallback);
+DeriveClass!(PxOverlapCallback);
 
 DeriveClass!(PxArticulationCache);
 


### PR DESCRIPTION
~Note that this pull request also reorganizes the examples, putting them into their own crate. I used [ash](https://github.com/MaikKlein/ash/tree/master/examples) as my example. This is likely going to break the current Github Actions, so I'll need to update that as well.~ Nevermind, I didn't actually know that Cargo had an explicit "examples" feature. Neat! Reverting these changes.

Simple hit buffers and full custom user-defined callbacks are supported.
It's not currently possible to specify the size of the buffer given to user-defined callbacks, but if everything else looks good, we can add support for that too.

Addresses https://github.com/EmbarkStudios/physx-rs/issues/99

@Hentropy 