### PR TITLE
Release Physx 0.10.0

### DIFF
--- a/physx/CHANGELOG.md
+++ b/physx/CHANGELOG.md
@@ -4,10 +4,14 @@
 
 ## [Unreleased]
 
+## [0.10.0]
+
 - [PR#113](https://github.com/EmbarkStudios/physx-rs/pull/98) Fix various issues
   found using physx-rs in practice after the big PR#98 merge from 0.9.0.
   You now create a scene using `Physics::create()` with a new scene descriptor
   that can represent all the parameters of PxSceneDesc.
+- [PR#120](https://github.com/EmbarkStudios/physx-rs/pull/120) Make convex and
+  triangle mesh validation optional.
 
 ## [0.9.0] - 2020-12-03
 
@@ -94,7 +98,8 @@
 - Ability to not run the default filter shader before the callback.
 - Fix for triangle mesh data when using glam with SSE enabled
 
-[Unreleased]: https://github.com/EmbarkStudios/physx-rs/compare/physx-v0.9.0...HEAD
+[Unreleased]: https://github.com/EmbarkStudios/physx-rs/compare/physx-v0.10.0...HEAD
+[0.10.0]: https://github.com/EmbarkStudios/physx-rs/compare/physx-v0.9.0...physx-v0.10.0
 [0.9.0]: https://github.com/EmbarkStudios/physx-rs/compare/physx-v0.8.0...physx-v0.9.0
 [0.8.0]: https://github.com/EmbarkStudios/physx-rs/compare/physx-v0.7.4...physx-v0.8.0
 [0.7.4]: https://github.com/EmbarkStudios/physx-rs/compare/physx-v0.7.3...physx-v0.7.4


### PR DESCRIPTION
Want to be able to use the latest changes, so even if there's stuff pending, let's make a release. Version numbers are free.

Only the high-level API has changes, physx-sys is not touched.

- [PR#113](https://github.com/EmbarkStudios/physx-rs/pull/98) Fix various issues found using physx-rs in practice after the big PR#98 merge from 0.9.0.  You now create a scene using `Physics::create()` with a new scene descriptor that can represent all the parameters of PxSceneDesc.

- [PR#120](https://github.com/EmbarkStudios/physx-rs/pull/120) Make convex and triangle mesh validation optional.