### PR TITLE
Initial aarch64-apple-darwin support

### DIFF
--- a/physx-sys/build.rs
+++ b/physx-sys/build.rs
@@ -155,7 +155,7 @@ fn main() {
         let mut include = PathBuf::from("src/generated");
 
         match target.as_str() {
-            "x86_64-apple-darwin" | "x86_64-pc-windows-msvc" | "aarch64-linux-android" => {
+            "x86_64-apple-darwin" | "x86_64-pc-windows-msvc" | "aarch64-linux-android" | "aarch64-apple-darwin" => {
                 include.push(target);
             }
             nix if nix.starts_with("x86_64-unknown-linux") => {

--- a/physx-sys/build.rs
+++ b/physx-sys/build.rs
@@ -155,7 +155,10 @@ fn main() {
         let mut include = PathBuf::from("src/generated");
 
         match target.as_str() {
-            "x86_64-apple-darwin" | "x86_64-pc-windows-msvc" | "aarch64-linux-android" | "aarch64-apple-darwin" => {
+            "x86_64-apple-darwin"
+            | "x86_64-pc-windows-msvc"
+            | "aarch64-linux-android"
+            | "aarch64-apple-darwin" => {
                 include.push(target);
             }
             nix if nix.starts_with("x86_64-unknown-linux") => {

--- a/physx-sys/src/generated/aarch64-apple-darwin/structgen.rs
+++ b/physx-sys/src/generated/aarch64-apple-darwin/structgen.rs
@@ -1,0 +1,2070 @@
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVec3 {
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+}
+#[test] fn check_size_PxVec3() { assert_eq!(std::mem::size_of::<PxVec3>(), 12); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxQuat {
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+    pub w: f32,
+}
+#[test] fn check_size_PxQuat() { assert_eq!(std::mem::size_of::<PxQuat>(), 16); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxMat33 {
+    pub column0: PxVec3,
+    pub column1: PxVec3,
+    pub column2: PxVec3,
+}
+#[test] fn check_size_PxMat33() { assert_eq!(std::mem::size_of::<PxMat33>(), 36); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxPlane {
+    pub n: PxVec3,
+    pub d: f32,
+}
+#[test] fn check_size_PxPlane() { assert_eq!(std::mem::size_of::<PxPlane>(), 16); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxTransform {
+    pub q: PxQuat,
+    pub p: PxVec3,
+}
+#[test] fn check_size_PxTransform() { assert_eq!(std::mem::size_of::<PxTransform>(), 28); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVec4 {
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+    pub w: f32,
+}
+#[test] fn check_size_PxVec4() { assert_eq!(std::mem::size_of::<PxVec4>(), 16); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxMat44 {
+    pub column0: PxVec4,
+    pub column1: PxVec4,
+    pub column2: PxVec4,
+    pub column3: PxVec4,
+}
+#[test] fn check_size_PxMat44() { assert_eq!(std::mem::size_of::<PxMat44>(), 64); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxBounds3 {
+    pub minimum: PxVec3,
+    pub maximum: PxVec3,
+}
+#[test] fn check_size_PxBounds3() { assert_eq!(std::mem::size_of::<PxBounds3>(), 24); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVec2 {
+    pub x: f32,
+    pub y: f32,
+}
+#[test] fn check_size_PxVec2() { assert_eq!(std::mem::size_of::<PxVec2>(), 8); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxStridedData {
+    pub stride: u32,
+    pub structgen_pad0: [u8; 4],
+    pub data: *const std::ffi::c_void,
+}
+#[test] fn check_size_PxStridedData() { assert_eq!(std::mem::size_of::<PxStridedData>(), 16); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxBoundedData {
+    pub stride: u32,
+    pub structgen_pad0: [u8; 4],
+    pub data: *const std::ffi::c_void,
+    pub count: u32,
+    pub structgen_pad1: [u8; 4],
+}
+#[test] fn check_size_PxBoundedData() { assert_eq!(std::mem::size_of::<PxBoundedData>(), 24); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxDebugPoint {
+    pub pos: PxVec3,
+    pub color: u32,
+}
+#[test] fn check_size_PxDebugPoint() { assert_eq!(std::mem::size_of::<PxDebugPoint>(), 16); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxDebugLine {
+    pub pos0: PxVec3,
+    pub color0: u32,
+    pub pos1: PxVec3,
+    pub color1: u32,
+}
+#[test] fn check_size_PxDebugLine() { assert_eq!(std::mem::size_of::<PxDebugLine>(), 32); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxDebugTriangle {
+    pub pos0: PxVec3,
+    pub color0: u32,
+    pub pos1: PxVec3,
+    pub color1: u32,
+    pub pos2: PxVec3,
+    pub color2: u32,
+}
+#[test] fn check_size_PxDebugTriangle() { assert_eq!(std::mem::size_of::<PxDebugTriangle>(), 48); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxDebugText {
+    pub position: PxVec3,
+    pub size: f32,
+    pub color: u32,
+    pub structgen_pad0: [u8; 4],
+    pub string: *const i8,
+}
+#[test] fn check_size_PxDebugText() { assert_eq!(std::mem::size_of::<PxDebugText>(), 32); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxBase {
+    pub structgen_pad0: [u8; 8],
+    pub mConcreteType: u16,
+    pub mBaseFlags: PxBaseFlags,
+    pub structgen_pad1: [u8; 4],
+}
+#[test] fn check_size_PxBase() { assert_eq!(std::mem::size_of::<PxBase>(), 16); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxDeserializationContext {
+    pub structgen_pad0: [u8; 8],
+    pub mExtraDataAddress: *mut u8,
+}
+#[test] fn check_size_PxDeserializationContext() { assert_eq!(std::mem::size_of::<PxDeserializationContext>(), 16); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxTolerancesScale {
+    pub length: f32,
+    pub speed: f32,
+}
+#[test] fn check_size_PxTolerancesScale() { assert_eq!(std::mem::size_of::<PxTolerancesScale>(), 8); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxTask {
+    pub structgen_pad0: [u8; 8],
+    pub mContextID: usize,
+    pub mTm: *mut PxTaskManager,
+    pub mTaskID: u32,
+    pub structgen_pad1: [u8; 4],
+}
+#[test] fn check_size_PxTask() { assert_eq!(std::mem::size_of::<PxTask>(), 32); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxBaseTask {
+    pub structgen_pad0: [u8; 8],
+    pub mContextID: usize,
+    pub mTm: *mut PxTaskManager,
+}
+#[test] fn check_size_PxBaseTask() { assert_eq!(std::mem::size_of::<PxBaseTask>(), 24); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxLightCpuTask {
+    pub structgen_pad0: [u8; 8],
+    pub mContextID: usize,
+    pub mTm: *mut PxTaskManager,
+    pub mCont: *mut PxBaseTask,
+    pub mRefCount: i32,
+    pub structgen_pad1: [u8; 4],
+}
+#[test] fn check_size_PxLightCpuTask() { assert_eq!(std::mem::size_of::<PxLightCpuTask>(), 40); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxGeometry {
+    pub mType: i32,
+}
+#[test] fn check_size_PxGeometry() { assert_eq!(std::mem::size_of::<PxGeometry>(), 4); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxBoxGeometry {
+    pub mType: i32,
+    pub halfExtents: PxVec3,
+}
+#[test] fn check_size_PxBoxGeometry() { assert_eq!(std::mem::size_of::<PxBoxGeometry>(), 16); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxBVHStructure {
+    pub structgen_pad0: [u8; 8],
+    pub mConcreteType: u16,
+    pub mBaseFlags: PxBaseFlags,
+    pub structgen_pad1: [u8; 4],
+}
+#[test] fn check_size_PxBVHStructure() { assert_eq!(std::mem::size_of::<PxBVHStructure>(), 16); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxCapsuleGeometry {
+    pub mType: i32,
+    pub radius: f32,
+    pub halfHeight: f32,
+}
+#[test] fn check_size_PxCapsuleGeometry() { assert_eq!(std::mem::size_of::<PxCapsuleGeometry>(), 12); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxConvexMesh {
+    pub structgen_pad0: [u8; 8],
+    pub mConcreteType: u16,
+    pub mBaseFlags: PxBaseFlags,
+    pub structgen_pad1: [u8; 4],
+}
+#[test] fn check_size_PxConvexMesh() { assert_eq!(std::mem::size_of::<PxConvexMesh>(), 16); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxHullPolygon {
+    pub mPlane: [f32; 4],
+    pub mNbVerts: u16,
+    pub mIndexBase: u16,
+}
+#[test] fn check_size_PxHullPolygon() { assert_eq!(std::mem::size_of::<PxHullPolygon>(), 20); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxMeshScale {
+    pub scale: PxVec3,
+    pub rotation: PxQuat,
+}
+#[test] fn check_size_PxMeshScale() { assert_eq!(std::mem::size_of::<PxMeshScale>(), 28); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxConvexMeshGeometry {
+    pub mType: i32,
+    pub scale: PxMeshScale,
+    pub convexMesh: *mut PxConvexMesh,
+    pub meshFlags: PxConvexMeshGeometryFlags,
+    pub paddingFromFlags: PxPadding_3_,
+    pub structgen_pad0: [u8; 4],
+}
+#[test] fn check_size_PxConvexMeshGeometry() { assert_eq!(std::mem::size_of::<PxConvexMeshGeometry>(), 48); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxSphereGeometry {
+    pub mType: i32,
+    pub radius: f32,
+}
+#[test] fn check_size_PxSphereGeometry() { assert_eq!(std::mem::size_of::<PxSphereGeometry>(), 8); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxPlaneGeometry {
+    pub mType: i32,
+}
+#[test] fn check_size_PxPlaneGeometry() { assert_eq!(std::mem::size_of::<PxPlaneGeometry>(), 4); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxTriangleMesh {
+    pub structgen_pad0: [u8; 8],
+    pub mConcreteType: u16,
+    pub mBaseFlags: PxBaseFlags,
+    pub structgen_pad1: [u8; 4],
+}
+#[test] fn check_size_PxTriangleMesh() { assert_eq!(std::mem::size_of::<PxTriangleMesh>(), 16); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxTriangleMeshGeometry {
+    pub mType: i32,
+    pub scale: PxMeshScale,
+    pub meshFlags: PxMeshGeometryFlags,
+    pub paddingFromFlags: PxPadding_3_,
+    pub structgen_pad0: [u8; 4],
+    pub triangleMesh: *mut PxTriangleMesh,
+}
+#[test] fn check_size_PxTriangleMeshGeometry() { assert_eq!(std::mem::size_of::<PxTriangleMeshGeometry>(), 48); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxHeightField {
+    pub structgen_pad0: [u8; 8],
+    pub mConcreteType: u16,
+    pub mBaseFlags: PxBaseFlags,
+    pub structgen_pad1: [u8; 4],
+}
+#[test] fn check_size_PxHeightField() { assert_eq!(std::mem::size_of::<PxHeightField>(), 16); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxHeightFieldGeometry {
+    pub mType: i32,
+    pub structgen_pad0: [u8; 4],
+    pub heightField: *mut PxHeightField,
+    pub heightScale: f32,
+    pub rowScale: f32,
+    pub columnScale: f32,
+    pub heightFieldFlags: PxMeshGeometryFlags,
+    pub paddingFromFlags: PxPadding_3_,
+}
+#[test] fn check_size_PxHeightFieldGeometry() { assert_eq!(std::mem::size_of::<PxHeightFieldGeometry>(), 32); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxGeometryHolder {
+    pub structgen_pad0: [u8; 48],
+}
+#[test] fn check_size_PxGeometryHolder() { assert_eq!(std::mem::size_of::<PxGeometryHolder>(), 48); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxRigidActor {
+    pub structgen_pad0: [u8; 8],
+    pub mConcreteType: u16,
+    pub mBaseFlags: PxBaseFlags,
+    pub structgen_pad1: [u8; 4],
+    pub userData: *mut std::ffi::c_void,
+}
+#[test] fn check_size_PxRigidActor() { assert_eq!(std::mem::size_of::<PxRigidActor>(), 24); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxShape {
+    pub structgen_pad0: [u8; 8],
+    pub mConcreteType: u16,
+    pub mBaseFlags: PxBaseFlags,
+    pub structgen_pad1: [u8; 4],
+    pub userData: *mut std::ffi::c_void,
+}
+#[test] fn check_size_PxShape() { assert_eq!(std::mem::size_of::<PxShape>(), 24); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxActorShape {
+    pub actor: *mut PxRigidActor,
+    pub shape: *mut PxShape,
+}
+#[test] fn check_size_PxActorShape() { assert_eq!(std::mem::size_of::<PxActorShape>(), 16); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxQueryHit {
+    pub actor: *mut PxRigidActor,
+    pub shape: *mut PxShape,
+    pub faceIndex: u32,
+    pub structgen_pad0: [u8; 4],
+}
+#[test] fn check_size_PxQueryHit() { assert_eq!(std::mem::size_of::<PxQueryHit>(), 24); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxLocationHit {
+    pub actor: *mut PxRigidActor,
+    pub shape: *mut PxShape,
+    pub faceIndex: u32,
+    pub flags: PxHitFlags,
+    pub structgen_pad0: [u8; 2],
+    pub position: PxVec3,
+    pub normal: PxVec3,
+    pub distance: f32,
+    pub structgen_pad1: [u8; 4],
+}
+#[test] fn check_size_PxLocationHit() { assert_eq!(std::mem::size_of::<PxLocationHit>(), 56); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxRaycastHit {
+    pub actor: *mut PxRigidActor,
+    pub shape: *mut PxShape,
+    pub faceIndex: u32,
+    pub flags: PxHitFlags,
+    pub structgen_pad0: [u8; 2],
+    pub position: PxVec3,
+    pub normal: PxVec3,
+    pub distance: f32,
+    pub u: f32,
+    pub v: f32,
+    pub structgen_pad1: [u8; 4],
+}
+#[test] fn check_size_PxRaycastHit() { assert_eq!(std::mem::size_of::<PxRaycastHit>(), 64); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxSweepHit {
+    pub actor: *mut PxRigidActor,
+    pub shape: *mut PxShape,
+    pub faceIndex: u32,
+    pub flags: PxHitFlags,
+    pub structgen_pad0: [u8; 2],
+    pub position: PxVec3,
+    pub normal: PxVec3,
+    pub distance: f32,
+    pub padTo16Bytes: u32,
+}
+#[test] fn check_size_PxSweepHit() { assert_eq!(std::mem::size_of::<PxSweepHit>(), 56); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxHeightFieldSample {
+    pub height: i16,
+    pub materialIndex0: PxBitAndByte,
+    pub materialIndex1: PxBitAndByte,
+}
+#[test] fn check_size_PxHeightFieldSample() { assert_eq!(std::mem::size_of::<PxHeightFieldSample>(), 4); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxHeightFieldDesc {
+    pub nbRows: u32,
+    pub nbColumns: u32,
+    pub format: u32,
+    pub structgen_pad0: [u8; 4],
+    pub samples: PxStridedData,
+    pub convexEdgeThreshold: f32,
+    pub flags: PxHeightFieldFlags,
+    pub structgen_pad1: [u8; 2],
+}
+#[test] fn check_size_PxHeightFieldDesc() { assert_eq!(std::mem::size_of::<PxHeightFieldDesc>(), 40); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxTriangle {
+    pub verts: [PxVec3; 3],
+}
+#[test] fn check_size_PxTriangle() { assert_eq!(std::mem::size_of::<PxTriangle>(), 36); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxSimpleTriangleMesh {
+    pub points: PxBoundedData,
+    pub triangles: PxBoundedData,
+    pub flags: PxMeshFlags,
+    pub structgen_pad0: [u8; 6],
+}
+#[test] fn check_size_PxSimpleTriangleMesh() { assert_eq!(std::mem::size_of::<PxSimpleTriangleMesh>(), 56); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxActor {
+    pub structgen_pad0: [u8; 8],
+    pub mConcreteType: u16,
+    pub mBaseFlags: PxBaseFlags,
+    pub structgen_pad1: [u8; 4],
+    pub userData: *mut std::ffi::c_void,
+}
+#[test] fn check_size_PxActor() { assert_eq!(std::mem::size_of::<PxActor>(), 24); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxScene {
+    pub structgen_pad0: [u8; 8],
+    pub userData: *mut std::ffi::c_void,
+}
+#[test] fn check_size_PxScene() { assert_eq!(std::mem::size_of::<PxScene>(), 16); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxAggregate {
+    pub structgen_pad0: [u8; 8],
+    pub mConcreteType: u16,
+    pub mBaseFlags: PxBaseFlags,
+    pub structgen_pad1: [u8; 4],
+}
+#[test] fn check_size_PxAggregate() { assert_eq!(std::mem::size_of::<PxAggregate>(), 16); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxArticulationBase {
+    pub structgen_pad0: [u8; 8],
+    pub mConcreteType: u16,
+    pub mBaseFlags: PxBaseFlags,
+    pub structgen_pad1: [u8; 4],
+    pub userData: *mut std::ffi::c_void,
+}
+#[test] fn check_size_PxArticulationBase() { assert_eq!(std::mem::size_of::<PxArticulationBase>(), 24); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxArticulationLink {
+    pub structgen_pad0: [u8; 8],
+    pub mConcreteType: u16,
+    pub mBaseFlags: PxBaseFlags,
+    pub structgen_pad1: [u8; 4],
+    pub userData: *mut std::ffi::c_void,
+}
+#[test] fn check_size_PxArticulationLink() { assert_eq!(std::mem::size_of::<PxArticulationLink>(), 24); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxArticulationJointBase {
+    pub structgen_pad0: [u8; 8],
+    pub mConcreteType: u16,
+    pub mBaseFlags: PxBaseFlags,
+    pub structgen_pad1: [u8; 4],
+}
+#[test] fn check_size_PxArticulationJointBase() { assert_eq!(std::mem::size_of::<PxArticulationJointBase>(), 16); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxArticulation {
+    pub structgen_pad0: [u8; 8],
+    pub mConcreteType: u16,
+    pub mBaseFlags: PxBaseFlags,
+    pub structgen_pad1: [u8; 4],
+    pub userData: *mut std::ffi::c_void,
+}
+#[test] fn check_size_PxArticulation() { assert_eq!(std::mem::size_of::<PxArticulation>(), 24); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxArticulationDriveCache {
+    pub structgen_pad0: [u8; 1],
+}
+#[test] fn check_size_PxArticulationDriveCache() { assert_eq!(std::mem::size_of::<PxArticulationDriveCache>(), 1); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxConstraintInvMassScale {
+    pub linear0: f32,
+    pub angular0: f32,
+    pub linear1: f32,
+    pub angular1: f32,
+}
+#[test] fn check_size_PxConstraintInvMassScale() { assert_eq!(std::mem::size_of::<PxConstraintInvMassScale>(), 16); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxConstraint {
+    pub structgen_pad0: [u8; 8],
+    pub mConcreteType: u16,
+    pub mBaseFlags: PxBaseFlags,
+    pub structgen_pad1: [u8; 4],
+}
+#[test] fn check_size_PxConstraint() { assert_eq!(std::mem::size_of::<PxConstraint>(), 16); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxSolverBody {
+    pub linearVelocity: PxVec3,
+    pub maxSolverNormalProgress: u16,
+    pub maxSolverFrictionProgress: u16,
+    pub angularState: PxVec3,
+    pub solverProgress: u32,
+}
+#[test] fn check_size_PxSolverBody() { assert_eq!(std::mem::size_of::<PxSolverBody>(), 32); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxSolverBodyData {
+    pub linearVelocity: PxVec3,
+    pub invMass: f32,
+    pub angularVelocity: PxVec3,
+    pub reportThreshold: f32,
+    pub sqrtInvInertia: PxMat33,
+    pub penBiasClamp: f32,
+    pub nodeIndex: u32,
+    pub maxContactImpulse: f32,
+    pub body2World: PxTransform,
+    pub lockFlags: u16,
+    pub pad: u16,
+}
+#[test] fn check_size_PxSolverBodyData() { assert_eq!(std::mem::size_of::<PxSolverBodyData>(), 112); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxTGSSolverBodyVel {
+    pub linearVelocity: PxVec3,
+    pub nbStaticInteractions: u16,
+    pub maxDynamicPartition: u16,
+    pub angularVelocity: PxVec3,
+    pub partitionMask: u32,
+    pub deltaAngDt: PxVec3,
+    pub maxAngVel: f32,
+    pub deltaLinDt: PxVec3,
+    pub lockFlags: u16,
+    pub isKinematic: bool,
+    pub pad: u8,
+}
+#[test] fn check_size_PxTGSSolverBodyVel() { assert_eq!(std::mem::size_of::<PxTGSSolverBodyVel>(), 64); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxTGSSolverBodyData {
+    pub originalLinearVelocity: PxVec3,
+    pub maxContactImpulse: f32,
+    pub originalAngularVelocity: PxVec3,
+    pub penBiasClamp: f32,
+    pub invMass: f32,
+    pub nodeIndex: u32,
+    pub reportThreshold: f32,
+    pub pad: u32,
+}
+#[test] fn check_size_PxTGSSolverBodyData() { assert_eq!(std::mem::size_of::<PxTGSSolverBodyData>(), 48); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxSpatialForce {
+    pub force: PxVec3,
+    pub pad0: f32,
+    pub torque: PxVec3,
+    pub pad1: f32,
+}
+#[test] fn check_size_PxSpatialForce() { assert_eq!(std::mem::size_of::<PxSpatialForce>(), 32); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxArticulationRootLinkData {
+    pub transform: PxTransform,
+    pub worldLinVel: PxVec3,
+    pub worldAngVel: PxVec3,
+    pub worldLinAccel: PxVec3,
+    pub worldAngAccel: PxVec3,
+}
+#[test] fn check_size_PxArticulationRootLinkData() { assert_eq!(std::mem::size_of::<PxArticulationRootLinkData>(), 76); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxArticulationCache {
+    pub externalForces: *mut PxSpatialForce,
+    pub denseJacobian: *mut f32,
+    pub massMatrix: *mut f32,
+    pub jointVelocity: *mut f32,
+    pub jointAcceleration: *mut f32,
+    pub jointPosition: *mut f32,
+    pub jointForce: *mut f32,
+    pub structgen_pad0: [u8; 16],
+    pub rootLinkData: *mut PxArticulationRootLinkData,
+    pub coefficientMatrix: *mut f32,
+    pub lambda: *mut f32,
+    pub scratchMemory: *mut std::ffi::c_void,
+    pub scratchAllocator: *mut std::ffi::c_void,
+    pub version: u32,
+    pub structgen_pad1: [u8; 4],
+}
+#[test] fn check_size_PxArticulationCache() { assert_eq!(std::mem::size_of::<PxArticulationCache>(), 120); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxArticulationReducedCoordinate {
+    pub structgen_pad0: [u8; 8],
+    pub mConcreteType: u16,
+    pub mBaseFlags: PxBaseFlags,
+    pub structgen_pad1: [u8; 4],
+    pub userData: *mut std::ffi::c_void,
+}
+#[test] fn check_size_PxArticulationReducedCoordinate() { assert_eq!(std::mem::size_of::<PxArticulationReducedCoordinate>(), 24); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxJoint {
+    pub structgen_pad0: [u8; 8],
+    pub mConcreteType: u16,
+    pub mBaseFlags: PxBaseFlags,
+    pub structgen_pad1: [u8; 4],
+    pub userData: *mut std::ffi::c_void,
+}
+#[test] fn check_size_PxJoint() { assert_eq!(std::mem::size_of::<PxJoint>(), 24); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxArticulationJoint {
+    pub structgen_pad0: [u8; 8],
+    pub mConcreteType: u16,
+    pub mBaseFlags: PxBaseFlags,
+    pub structgen_pad1: [u8; 4],
+}
+#[test] fn check_size_PxArticulationJoint() { assert_eq!(std::mem::size_of::<PxArticulationJoint>(), 16); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxArticulationJointReducedCoordinate {
+    pub structgen_pad0: [u8; 8],
+    pub mConcreteType: u16,
+    pub mBaseFlags: PxBaseFlags,
+    pub structgen_pad1: [u8; 4],
+}
+#[test] fn check_size_PxArticulationJointReducedCoordinate() { assert_eq!(std::mem::size_of::<PxArticulationJointReducedCoordinate>(), 16); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxFilterData {
+    pub word0: u32,
+    pub word1: u32,
+    pub word2: u32,
+    pub word3: u32,
+}
+#[test] fn check_size_PxFilterData() { assert_eq!(std::mem::size_of::<PxFilterData>(), 16); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxMaterial {
+    pub structgen_pad0: [u8; 8],
+    pub mConcreteType: u16,
+    pub mBaseFlags: PxBaseFlags,
+    pub structgen_pad1: [u8; 4],
+    pub userData: *mut std::ffi::c_void,
+}
+#[test] fn check_size_PxMaterial() { assert_eq!(std::mem::size_of::<PxMaterial>(), 24); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxRigidBody {
+    pub structgen_pad0: [u8; 8],
+    pub mConcreteType: u16,
+    pub mBaseFlags: PxBaseFlags,
+    pub structgen_pad1: [u8; 4],
+    pub userData: *mut std::ffi::c_void,
+}
+#[test] fn check_size_PxRigidBody() { assert_eq!(std::mem::size_of::<PxRigidBody>(), 24); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxQueryFilterData {
+    pub data: PxFilterData,
+    pub flags: PxQueryFlags,
+    pub structgen_pad0: [u8; 2],
+}
+#[test] fn check_size_PxQueryFilterData() { assert_eq!(std::mem::size_of::<PxQueryFilterData>(), 20); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxOverlapHit {
+    pub actor: *mut PxRigidActor,
+    pub shape: *mut PxShape,
+    pub faceIndex: u32,
+    pub padTo16Bytes: u32,
+}
+#[test] fn check_size_PxOverlapHit() { assert_eq!(std::mem::size_of::<PxOverlapHit>(), 24); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxBatchQueryMemory {
+    pub userRaycastResultBuffer: *mut PxRaycastQueryResult,
+    pub userRaycastTouchBuffer: *mut PxRaycastHit,
+    pub userSweepResultBuffer: *mut PxSweepQueryResult,
+    pub userSweepTouchBuffer: *mut PxSweepHit,
+    pub userOverlapResultBuffer: *mut PxOverlapQueryResult,
+    pub userOverlapTouchBuffer: *mut PxOverlapHit,
+    pub raycastTouchBufferSize: u32,
+    pub sweepTouchBufferSize: u32,
+    pub overlapTouchBufferSize: u32,
+    pub raycastResultBufferSize: u32,
+    pub sweepResultBufferSize: u32,
+    pub overlapResultBufferSize: u32,
+}
+#[test] fn check_size_PxBatchQueryMemory() { assert_eq!(std::mem::size_of::<PxBatchQueryMemory>(), 72); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxBatchQueryDesc {
+    pub filterShaderData: *mut std::ffi::c_void,
+    pub filterShaderDataSize: u32,
+    pub structgen_pad0: [u8; 4],
+    pub preFilterShader: *mut std::ffi::c_void,
+    pub postFilterShader: *mut std::ffi::c_void,
+    pub queryMemory: PxBatchQueryMemory,
+}
+#[test] fn check_size_PxBatchQueryDesc() { assert_eq!(std::mem::size_of::<PxBatchQueryDesc>(), 104); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxQueryCache {
+    pub shape: *mut PxShape,
+    pub actor: *mut PxRigidActor,
+    pub faceIndex: u32,
+    pub structgen_pad0: [u8; 4],
+}
+#[test] fn check_size_PxQueryCache() { assert_eq!(std::mem::size_of::<PxQueryCache>(), 24); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxConstraintShaderTable {
+    pub solverPrep: *mut std::ffi::c_void,
+    pub project: *mut std::ffi::c_void,
+    pub visualize: *mut std::ffi::c_void,
+    pub flag: u32,
+    pub structgen_pad0: [u8; 4],
+}
+#[test] fn check_size_PxConstraintShaderTable() { assert_eq!(std::mem::size_of::<PxConstraintShaderTable>(), 32); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxMassModificationProps {
+    pub mInvMassScale0: f32,
+    pub mInvInertiaScale0: f32,
+    pub mInvMassScale1: f32,
+    pub mInvInertiaScale1: f32,
+}
+#[test] fn check_size_PxMassModificationProps() { assert_eq!(std::mem::size_of::<PxMassModificationProps>(), 16); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxContactPatch {
+    pub mMassModification: PxMassModificationProps,
+    pub normal: PxVec3,
+    pub restitution: f32,
+    pub dynamicFriction: f32,
+    pub staticFriction: f32,
+    pub startContactIndex: u8,
+    pub nbContacts: u8,
+    pub materialFlags: u8,
+    pub internalFlags: u8,
+    pub materialIndex0: u16,
+    pub materialIndex1: u16,
+}
+#[test] fn check_size_PxContactPatch() { assert_eq!(std::mem::size_of::<PxContactPatch>(), 48); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxContact {
+    pub contact: PxVec3,
+    pub separation: f32,
+}
+#[test] fn check_size_PxContact() { assert_eq!(std::mem::size_of::<PxContact>(), 16); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxContactStreamIterator {
+    pub zero: PxVec3,
+    pub structgen_pad0: [u8; 4],
+    pub patch: *const PxContactPatch,
+    pub contact: *const PxContact,
+    pub faceIndice: *const u32,
+    pub totalPatches: u32,
+    pub totalContacts: u32,
+    pub nextContactIndex: u32,
+    pub nextPatchIndex: u32,
+    pub contactPatchHeaderSize: u32,
+    pub contactPointSize: u32,
+    pub mStreamFormat: u32,
+    pub forceNoResponse: u32,
+    pub pointStepped: bool,
+    pub structgen_pad1: [u8; 3],
+    pub hasFaceIndices: u32,
+}
+#[test] fn check_size_PxContactStreamIterator() { assert_eq!(std::mem::size_of::<PxContactStreamIterator>(), 80); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxModifiableContact {
+    pub contact: PxVec3,
+    pub separation: f32,
+    pub targetVelocity: PxVec3,
+    pub maxImpulse: f32,
+    pub normal: PxVec3,
+    pub restitution: f32,
+    pub materialFlags: u32,
+    pub materialIndex0: u16,
+    pub materialIndex1: u16,
+    pub staticFriction: f32,
+    pub dynamicFriction: f32,
+}
+#[test] fn check_size_PxModifiableContact() { assert_eq!(std::mem::size_of::<PxModifiableContact>(), 64); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxContactSet {
+    pub mCount: u32,
+    pub structgen_pad0: [u8; 4],
+    pub mContacts: *mut PxModifiableContact,
+}
+#[test] fn check_size_PxContactSet() { assert_eq!(std::mem::size_of::<PxContactSet>(), 16); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxContactModifyPair {
+    pub actor: [*const PxRigidActor; 2],
+    pub shape: [*const PxShape; 2],
+    pub transform: [PxTransform; 2],
+    pub contacts: PxContactSet,
+}
+#[test] fn check_size_PxContactModifyPair() { assert_eq!(std::mem::size_of::<PxContactModifyPair>(), 104); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxSceneLimits {
+    pub maxNbActors: u32,
+    pub maxNbBodies: u32,
+    pub maxNbStaticShapes: u32,
+    pub maxNbDynamicShapes: u32,
+    pub maxNbAggregates: u32,
+    pub maxNbConstraints: u32,
+    pub maxNbRegions: u32,
+    pub maxNbBroadPhaseOverlaps: u32,
+}
+#[test] fn check_size_PxSceneLimits() { assert_eq!(std::mem::size_of::<PxSceneLimits>(), 32); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxgDynamicsMemoryConfig {
+    pub constraintBufferCapacity: u32,
+    pub contactBufferCapacity: u32,
+    pub tempBufferCapacity: u32,
+    pub contactStreamSize: u32,
+    pub patchStreamSize: u32,
+    pub forceStreamCapacity: u32,
+    pub heapCapacity: u32,
+    pub foundLostPairsCapacity: u32,
+}
+#[test] fn check_size_PxgDynamicsMemoryConfig() { assert_eq!(std::mem::size_of::<PxgDynamicsMemoryConfig>(), 32); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxSceneDesc {
+    pub gravity: PxVec3,
+    pub structgen_pad0: [u8; 4],
+    pub simulationEventCallback: *mut PxSimulationEventCallback,
+    pub contactModifyCallback: *mut PxContactModifyCallback,
+    pub ccdContactModifyCallback: *mut PxCCDContactModifyCallback,
+    pub filterShaderData: *const std::ffi::c_void,
+    pub filterShaderDataSize: u32,
+    pub structgen_pad1: [u8; 4],
+    pub filterShader: *mut std::ffi::c_void,
+    pub filterCallback: *mut PxSimulationFilterCallback,
+    pub kineKineFilteringMode: u32,
+    pub staticKineFilteringMode: u32,
+    pub broadPhaseType: u32,
+    pub structgen_pad2: [u8; 4],
+    pub broadPhaseCallback: *mut PxBroadPhaseCallback,
+    pub limits: PxSceneLimits,
+    pub frictionType: u32,
+    pub solverType: u32,
+    pub bounceThresholdVelocity: f32,
+    pub frictionOffsetThreshold: f32,
+    pub ccdMaxSeparation: f32,
+    pub solverOffsetSlop: f32,
+    pub flags: PxSceneFlags,
+    pub structgen_pad3: [u8; 4],
+    pub cpuDispatcher: *mut PxCpuDispatcher,
+    pub cudaContextManager: *mut PxCudaContextManager,
+    pub staticStructure: u32,
+    pub dynamicStructure: u32,
+    pub dynamicTreeRebuildRateHint: u32,
+    pub sceneQueryUpdateMode: u32,
+    pub userData: *mut std::ffi::c_void,
+    pub solverBatchSize: u32,
+    pub solverArticulationBatchSize: u32,
+    pub nbContactDataBlocks: u32,
+    pub maxNbContactDataBlocks: u32,
+    pub maxBiasCoefficient: f32,
+    pub contactReportStreamBufferSize: u32,
+    pub ccdMaxPasses: u32,
+    pub ccdThreshold: f32,
+    pub wakeCounterResetValue: f32,
+    pub sanityBounds: PxBounds3,
+    pub gpuDynamicsConfig: PxgDynamicsMemoryConfig,
+    pub gpuMaxNumPartitions: u32,
+    pub gpuComputeVersion: u32,
+    pub structgen_pad4: [u8; 12],
+}
+#[test] fn check_size_PxSceneDesc() { assert_eq!(std::mem::size_of::<PxSceneDesc>(), 312); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxRigidStatic {
+    pub structgen_pad0: [u8; 8],
+    pub mConcreteType: u16,
+    pub mBaseFlags: PxBaseFlags,
+    pub structgen_pad1: [u8; 4],
+    pub userData: *mut std::ffi::c_void,
+}
+#[test] fn check_size_PxRigidStatic() { assert_eq!(std::mem::size_of::<PxRigidStatic>(), 24); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxRigidDynamic {
+    pub structgen_pad0: [u8; 8],
+    pub mConcreteType: u16,
+    pub mBaseFlags: PxBaseFlags,
+    pub structgen_pad1: [u8; 4],
+    pub userData: *mut std::ffi::c_void,
+}
+#[test] fn check_size_PxRigidDynamic() { assert_eq!(std::mem::size_of::<PxRigidDynamic>(), 24); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxPruningStructure {
+    pub structgen_pad0: [u8; 8],
+    pub mConcreteType: u16,
+    pub mBaseFlags: PxBaseFlags,
+    pub structgen_pad1: [u8; 4],
+}
+#[test] fn check_size_PxPruningStructure() { assert_eq!(std::mem::size_of::<PxPruningStructure>(), 16); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxSimulationStatistics {
+    pub nbActiveConstraints: u32,
+    pub nbActiveDynamicBodies: u32,
+    pub nbActiveKinematicBodies: u32,
+    pub nbStaticBodies: u32,
+    pub nbDynamicBodies: u32,
+    pub nbKinematicBodies: u32,
+    pub nbShapes: [u32; 7],
+    pub nbAggregates: u32,
+    pub nbArticulations: u32,
+    pub nbAxisSolverConstraints: u32,
+    pub compressedContactSize: u32,
+    pub requiredContactConstraintMemory: u32,
+    pub peakConstraintMemory: u32,
+    pub nbDiscreteContactPairsTotal: u32,
+    pub nbDiscreteContactPairsWithCacheHits: u32,
+    pub nbDiscreteContactPairsWithContacts: u32,
+    pub nbNewPairs: u32,
+    pub nbLostPairs: u32,
+    pub nbNewTouches: u32,
+    pub nbLostTouches: u32,
+    pub nbPartitions: u32,
+    pub nbBroadPhaseAdds: u32,
+    pub nbBroadPhaseRemoves: u32,
+    pub nbDiscreteContactPairs: [[u32; 7]; 7],
+    pub nbCCDPairs: [[u32; 7]; 7],
+    pub nbModifiedContactPairs: [[u32; 7]; 7],
+    pub nbTriggerPairs: [[u32; 7]; 7],
+}
+#[test] fn check_size_PxSimulationStatistics() { assert_eq!(std::mem::size_of::<PxSimulationStatistics>(), 900); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxDominanceGroupPair {
+    pub dominance0: u8,
+    pub dominance1: u8,
+}
+#[test] fn check_size_PxDominanceGroupPair() { assert_eq!(std::mem::size_of::<PxDominanceGroupPair>(), 2); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxContactPair {
+    pub shapes: [*mut PxShape; 2],
+    pub contactPatches: *const u8,
+    pub contactPoints: *const u8,
+    pub contactImpulses: *const f32,
+    pub requiredBufferSize: u32,
+    pub contactCount: u8,
+    pub patchCount: u8,
+    pub contactStreamSize: u16,
+    pub flags: PxContactPairFlags,
+    pub events: PxPairFlags,
+    pub internalData: [u32; 2],
+    pub structgen_pad0: [u8; 4],
+}
+#[test] fn check_size_PxContactPair() { assert_eq!(std::mem::size_of::<PxContactPair>(), 64); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxContactPairHeader {
+    pub actors: [*mut PxRigidActor; 2],
+    pub extraDataStream: *const u8,
+    pub extraDataStreamSize: u16,
+    pub flags: PxContactPairHeaderFlags,
+    pub structgen_pad0: [u8; 4],
+    pub pairs: *const PxContactPair,
+    pub nbPairs: u32,
+    pub structgen_pad1: [u8; 4],
+}
+#[test] fn check_size_PxContactPairHeader() { assert_eq!(std::mem::size_of::<PxContactPairHeader>(), 48); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxBroadPhaseCaps {
+    pub maxNbRegions: u32,
+    pub maxNbObjects: u32,
+    pub needsPredefinedBounds: bool,
+    pub structgen_pad0: [u8; 3],
+}
+#[test] fn check_size_PxBroadPhaseCaps() { assert_eq!(std::mem::size_of::<PxBroadPhaseCaps>(), 12); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxBroadPhaseRegion {
+    pub bounds: PxBounds3,
+    pub userData: *mut std::ffi::c_void,
+}
+#[test] fn check_size_PxBroadPhaseRegion() { assert_eq!(std::mem::size_of::<PxBroadPhaseRegion>(), 32); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxBroadPhaseRegionInfo {
+    pub region: PxBroadPhaseRegion,
+    pub nbStaticObjects: u32,
+    pub nbDynamicObjects: u32,
+    pub active: bool,
+    pub overlap: bool,
+    pub structgen_pad0: [u8; 6],
+}
+#[test] fn check_size_PxBroadPhaseRegionInfo() { assert_eq!(std::mem::size_of::<PxBroadPhaseRegionInfo>(), 48); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxSceneReadLock {
+    pub structgen_pad0: [u8; 8],
+}
+#[test] fn check_size_PxSceneReadLock() { assert_eq!(std::mem::size_of::<PxSceneReadLock>(), 8); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxSceneWriteLock {
+    pub structgen_pad0: [u8; 8],
+}
+#[test] fn check_size_PxSceneWriteLock() { assert_eq!(std::mem::size_of::<PxSceneWriteLock>(), 8); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxContactPairExtraDataItem {
+    pub _type: u8,
+}
+#[test] fn check_size_PxContactPairExtraDataItem() { assert_eq!(std::mem::size_of::<PxContactPairExtraDataItem>(), 1); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxContactPairVelocity {
+    pub _type: u8,
+    pub structgen_pad0: [u8; 3],
+    pub linearVelocity: [PxVec3; 2],
+    pub angularVelocity: [PxVec3; 2],
+}
+#[test] fn check_size_PxContactPairVelocity() { assert_eq!(std::mem::size_of::<PxContactPairVelocity>(), 52); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxContactPairPose {
+    pub _type: u8,
+    pub structgen_pad0: [u8; 3],
+    pub globalPose: [PxTransform; 2],
+}
+#[test] fn check_size_PxContactPairPose() { assert_eq!(std::mem::size_of::<PxContactPairPose>(), 60); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxContactPairIndex {
+    pub _type: u8,
+    pub structgen_pad0: [u8; 1],
+    pub index: u16,
+}
+#[test] fn check_size_PxContactPairIndex() { assert_eq!(std::mem::size_of::<PxContactPairIndex>(), 4); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxContactPairExtraDataIterator {
+    pub currPtr: *const u8,
+    pub endPtr: *const u8,
+    pub preSolverVelocity: *const PxContactPairVelocity,
+    pub postSolverVelocity: *const PxContactPairVelocity,
+    pub eventPose: *const PxContactPairPose,
+    pub contactPairIndex: u32,
+    pub structgen_pad0: [u8; 4],
+}
+#[test] fn check_size_PxContactPairExtraDataIterator() { assert_eq!(std::mem::size_of::<PxContactPairExtraDataIterator>(), 48); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxContactPairPoint {
+    pub position: PxVec3,
+    pub separation: f32,
+    pub normal: PxVec3,
+    pub internalFaceIndex0: u32,
+    pub impulse: PxVec3,
+    pub internalFaceIndex1: u32,
+}
+#[test] fn check_size_PxContactPairPoint() { assert_eq!(std::mem::size_of::<PxContactPairPoint>(), 48); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxTriggerPair {
+    pub triggerShape: *mut PxShape,
+    pub triggerActor: *mut PxRigidActor,
+    pub otherShape: *mut PxShape,
+    pub otherActor: *mut PxRigidActor,
+    pub status: u32,
+    pub flags: PxTriggerPairFlags,
+    pub structgen_pad0: [u8; 3],
+}
+#[test] fn check_size_PxTriggerPair() { assert_eq!(std::mem::size_of::<PxTriggerPair>(), 40); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxConstraintInfo {
+    pub constraint: *mut PxConstraint,
+    pub externalReference: *mut std::ffi::c_void,
+    pub _type: u32,
+    pub structgen_pad0: [u8; 4],
+}
+#[test] fn check_size_PxConstraintInfo() { assert_eq!(std::mem::size_of::<PxConstraintInfo>(), 24); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxExtendedVec3 {
+    pub x: f64,
+    pub y: f64,
+    pub z: f64,
+}
+#[test] fn check_size_PxExtendedVec3() { assert_eq!(std::mem::size_of::<PxExtendedVec3>(), 24); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxObstacle {
+    pub mType: i32,
+    pub structgen_pad0: [u8; 4],
+    pub mUserData: *mut std::ffi::c_void,
+    pub mPos: PxExtendedVec3,
+    pub mRot: PxQuat,
+}
+#[test] fn check_size_PxObstacle() { assert_eq!(std::mem::size_of::<PxObstacle>(), 56); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxBoxObstacle {
+    pub mType: i32,
+    pub structgen_pad0: [u8; 4],
+    pub mUserData: *mut std::ffi::c_void,
+    pub mPos: PxExtendedVec3,
+    pub mRot: PxQuat,
+    pub mHalfExtents: PxVec3,
+    pub structgen_pad1: [u8; 4],
+}
+#[test] fn check_size_PxBoxObstacle() { assert_eq!(std::mem::size_of::<PxBoxObstacle>(), 72); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxCapsuleObstacle {
+    pub mType: i32,
+    pub structgen_pad0: [u8; 4],
+    pub mUserData: *mut std::ffi::c_void,
+    pub mPos: PxExtendedVec3,
+    pub mRot: PxQuat,
+    pub mHalfHeight: f32,
+    pub mRadius: f32,
+}
+#[test] fn check_size_PxCapsuleObstacle() { assert_eq!(std::mem::size_of::<PxCapsuleObstacle>(), 64); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxControllerShapeHit {
+    pub controller: *mut PxController,
+    pub worldPos: PxExtendedVec3,
+    pub worldNormal: PxVec3,
+    pub dir: PxVec3,
+    pub length: f32,
+    pub structgen_pad0: [u8; 4],
+    pub shape: *mut PxShape,
+    pub actor: *mut PxRigidActor,
+    pub triangleIndex: u32,
+    pub structgen_pad1: [u8; 4],
+}
+#[test] fn check_size_PxControllerShapeHit() { assert_eq!(std::mem::size_of::<PxControllerShapeHit>(), 88); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxControllersHit {
+    pub controller: *mut PxController,
+    pub worldPos: PxExtendedVec3,
+    pub worldNormal: PxVec3,
+    pub dir: PxVec3,
+    pub length: f32,
+    pub structgen_pad0: [u8; 4],
+    pub other: *mut PxController,
+}
+#[test] fn check_size_PxControllersHit() { assert_eq!(std::mem::size_of::<PxControllersHit>(), 72); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxControllerObstacleHit {
+    pub controller: *mut PxController,
+    pub worldPos: PxExtendedVec3,
+    pub worldNormal: PxVec3,
+    pub dir: PxVec3,
+    pub length: f32,
+    pub structgen_pad0: [u8; 4],
+    pub userData: *const std::ffi::c_void,
+}
+#[test] fn check_size_PxControllerObstacleHit() { assert_eq!(std::mem::size_of::<PxControllerObstacleHit>(), 72); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxControllerFilters {
+    pub mFilterData: *const PxFilterData,
+    pub mFilterCallback: *mut PxQueryFilterCallback,
+    pub mFilterFlags: PxQueryFlags,
+    pub structgen_pad0: [u8; 6],
+    pub mCCTFilterCallback: *mut PxControllerFilterCallback,
+}
+#[test] fn check_size_PxControllerFilters() { assert_eq!(std::mem::size_of::<PxControllerFilters>(), 32); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxControllerDesc {
+    pub structgen_pad0: [u8; 8],
+    pub position: PxExtendedVec3,
+    pub upDirection: PxVec3,
+    pub slopeLimit: f32,
+    pub invisibleWallHeight: f32,
+    pub maxJumpHeight: f32,
+    pub contactOffset: f32,
+    pub stepOffset: f32,
+    pub density: f32,
+    pub scaleCoeff: f32,
+    pub volumeGrowth: f32,
+    pub structgen_pad1: [u8; 4],
+    pub reportCallback: *mut PxUserControllerHitReport,
+    pub behaviorCallback: *mut PxControllerBehaviorCallback,
+    pub nonWalkableMode: u32,
+    pub structgen_pad2: [u8; 4],
+    pub material: *mut PxMaterial,
+    pub registerDeletionListener: bool,
+    pub structgen_pad3: [u8; 7],
+    pub userData: *mut std::ffi::c_void,
+    pub mType: u32,
+    pub structgen_pad4: [u8; 4],
+}
+#[test] fn check_size_PxControllerDesc() { assert_eq!(std::mem::size_of::<PxControllerDesc>(), 136); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxControllerState {
+    pub deltaXP: PxVec3,
+    pub structgen_pad0: [u8; 4],
+    pub touchedShape: *mut PxShape,
+    pub touchedActor: *mut PxRigidActor,
+    pub touchedObstacleHandle: u32,
+    pub collisionFlags: u32,
+    pub standOnAnotherCCT: bool,
+    pub standOnObstacle: bool,
+    pub isMovingUp: bool,
+    pub structgen_pad1: [u8; 5],
+}
+#[test] fn check_size_PxControllerState() { assert_eq!(std::mem::size_of::<PxControllerState>(), 48); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxControllerStats {
+    pub nbIterations: u16,
+    pub nbFullUpdates: u16,
+    pub nbPartialUpdates: u16,
+    pub nbTessellation: u16,
+}
+#[test] fn check_size_PxControllerStats() { assert_eq!(std::mem::size_of::<PxControllerStats>(), 8); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxBoxControllerDesc {
+    pub structgen_pad0: [u8; 8],
+    pub position: PxExtendedVec3,
+    pub upDirection: PxVec3,
+    pub slopeLimit: f32,
+    pub invisibleWallHeight: f32,
+    pub maxJumpHeight: f32,
+    pub contactOffset: f32,
+    pub stepOffset: f32,
+    pub density: f32,
+    pub scaleCoeff: f32,
+    pub volumeGrowth: f32,
+    pub structgen_pad1: [u8; 4],
+    pub reportCallback: *mut PxUserControllerHitReport,
+    pub behaviorCallback: *mut PxControllerBehaviorCallback,
+    pub nonWalkableMode: u32,
+    pub structgen_pad2: [u8; 4],
+    pub material: *mut PxMaterial,
+    pub registerDeletionListener: bool,
+    pub structgen_pad3: [u8; 7],
+    pub userData: *mut std::ffi::c_void,
+    pub mType: u32,
+    pub halfHeight: f32,
+    pub halfSideExtent: f32,
+    pub halfForwardExtent: f32,
+}
+#[test] fn check_size_PxBoxControllerDesc() { assert_eq!(std::mem::size_of::<PxBoxControllerDesc>(), 144); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxCapsuleControllerDesc {
+    pub structgen_pad0: [u8; 8],
+    pub position: PxExtendedVec3,
+    pub upDirection: PxVec3,
+    pub slopeLimit: f32,
+    pub invisibleWallHeight: f32,
+    pub maxJumpHeight: f32,
+    pub contactOffset: f32,
+    pub stepOffset: f32,
+    pub density: f32,
+    pub scaleCoeff: f32,
+    pub volumeGrowth: f32,
+    pub structgen_pad1: [u8; 4],
+    pub reportCallback: *mut PxUserControllerHitReport,
+    pub behaviorCallback: *mut PxControllerBehaviorCallback,
+    pub nonWalkableMode: u32,
+    pub structgen_pad2: [u8; 4],
+    pub material: *mut PxMaterial,
+    pub registerDeletionListener: bool,
+    pub structgen_pad3: [u8; 7],
+    pub userData: *mut std::ffi::c_void,
+    pub mType: u32,
+    pub radius: f32,
+    pub height: f32,
+    pub climbingMode: u32,
+}
+#[test] fn check_size_PxCapsuleControllerDesc() { assert_eq!(std::mem::size_of::<PxCapsuleControllerDesc>(), 144); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxConvexMeshDesc {
+    pub points: PxBoundedData,
+    pub polygons: PxBoundedData,
+    pub indices: PxBoundedData,
+    pub flags: PxConvexFlags,
+    pub vertexLimit: u16,
+    pub quantizedCount: u16,
+    pub structgen_pad0: [u8; 2],
+}
+#[test] fn check_size_PxConvexMeshDesc() { assert_eq!(std::mem::size_of::<PxConvexMeshDesc>(), 80); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxTriangleMeshDesc {
+    pub points: PxBoundedData,
+    pub triangles: PxBoundedData,
+    pub flags: PxMeshFlags,
+    pub structgen_pad0: [u8; 6],
+    pub materialIndices: PxTypedStridedData_physx_PxMaterialTableIndex_,
+}
+#[test] fn check_size_PxTriangleMeshDesc() { assert_eq!(std::mem::size_of::<PxTriangleMeshDesc>(), 72); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxBVH33MidphaseDesc {
+    pub meshSizePerformanceTradeOff: f32,
+    pub meshCookingHint: u32,
+}
+#[test] fn check_size_PxBVH33MidphaseDesc() { assert_eq!(std::mem::size_of::<PxBVH33MidphaseDesc>(), 8); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxBVH34MidphaseDesc {
+    pub numPrimsPerLeaf: u32,
+}
+#[test] fn check_size_PxBVH34MidphaseDesc() { assert_eq!(std::mem::size_of::<PxBVH34MidphaseDesc>(), 4); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxMidphaseDesc {
+    pub structgen_pad0: [u8; 8],
+    pub mType: u32,
+}
+#[test] fn check_size_PxMidphaseDesc() { assert_eq!(std::mem::size_of::<PxMidphaseDesc>(), 12); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxBVHStructureDesc {
+    pub bounds: PxBoundedData,
+}
+#[test] fn check_size_PxBVHStructureDesc() { assert_eq!(std::mem::size_of::<PxBVHStructureDesc>(), 24); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxCookingParams {
+    pub areaTestEpsilon: f32,
+    pub planeTolerance: f32,
+    pub convexMeshCookingType: u32,
+    pub suppressTriangleMeshRemapTable: bool,
+    pub buildTriangleAdjacencies: bool,
+    pub buildGPUData: bool,
+    pub structgen_pad0: [u8; 1],
+    pub scale: PxTolerancesScale,
+    pub meshPreprocessParams: PxMeshPreprocessingFlags,
+    pub meshWeldTolerance: f32,
+    pub midphaseDesc: PxMidphaseDesc,
+    pub gaussMapLimit: u32,
+}
+#[test] fn check_size_PxCookingParams() { assert_eq!(std::mem::size_of::<PxCookingParams>(), 48); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxDefaultMemoryOutputStream {
+    pub structgen_pad0: [u8; 32],
+}
+#[test] fn check_size_PxDefaultMemoryOutputStream() { assert_eq!(std::mem::size_of::<PxDefaultMemoryOutputStream>(), 32); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxDefaultMemoryInputData {
+    pub structgen_pad0: [u8; 32],
+}
+#[test] fn check_size_PxDefaultMemoryInputData() { assert_eq!(std::mem::size_of::<PxDefaultMemoryInputData>(), 32); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxDefaultFileOutputStream {
+    pub structgen_pad0: [u8; 16],
+}
+#[test] fn check_size_PxDefaultFileOutputStream() { assert_eq!(std::mem::size_of::<PxDefaultFileOutputStream>(), 16); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxDefaultFileInputData {
+    pub structgen_pad0: [u8; 24],
+}
+#[test] fn check_size_PxDefaultFileInputData() { assert_eq!(std::mem::size_of::<PxDefaultFileInputData>(), 24); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxSpring {
+    pub stiffness: f32,
+    pub damping: f32,
+}
+#[test] fn check_size_PxSpring() { assert_eq!(std::mem::size_of::<PxSpring>(), 8); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxDistanceJoint {
+    pub structgen_pad0: [u8; 8],
+    pub mConcreteType: u16,
+    pub mBaseFlags: PxBaseFlags,
+    pub structgen_pad1: [u8; 4],
+    pub userData: *mut std::ffi::c_void,
+}
+#[test] fn check_size_PxDistanceJoint() { assert_eq!(std::mem::size_of::<PxDistanceJoint>(), 24); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxContactJoint {
+    pub structgen_pad0: [u8; 8],
+    pub mConcreteType: u16,
+    pub mBaseFlags: PxBaseFlags,
+    pub structgen_pad1: [u8; 4],
+    pub userData: *mut std::ffi::c_void,
+}
+#[test] fn check_size_PxContactJoint() { assert_eq!(std::mem::size_of::<PxContactJoint>(), 24); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxJacobianRow {
+    pub linear0: PxVec3,
+    pub linear1: PxVec3,
+    pub angular0: PxVec3,
+    pub angular1: PxVec3,
+}
+#[test] fn check_size_PxJacobianRow() { assert_eq!(std::mem::size_of::<PxJacobianRow>(), 48); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxFixedJoint {
+    pub structgen_pad0: [u8; 8],
+    pub mConcreteType: u16,
+    pub mBaseFlags: PxBaseFlags,
+    pub structgen_pad1: [u8; 4],
+    pub userData: *mut std::ffi::c_void,
+}
+#[test] fn check_size_PxFixedJoint() { assert_eq!(std::mem::size_of::<PxFixedJoint>(), 24); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxJointLimitParameters {
+    pub restitution: f32,
+    pub bounceThreshold: f32,
+    pub stiffness: f32,
+    pub damping: f32,
+    pub contactDistance: f32,
+}
+#[test] fn check_size_PxJointLimitParameters() { assert_eq!(std::mem::size_of::<PxJointLimitParameters>(), 20); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxJointLinearLimit {
+    pub restitution: f32,
+    pub bounceThreshold: f32,
+    pub stiffness: f32,
+    pub damping: f32,
+    pub contactDistance: f32,
+    pub value: f32,
+}
+#[test] fn check_size_PxJointLinearLimit() { assert_eq!(std::mem::size_of::<PxJointLinearLimit>(), 24); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxJointLinearLimitPair {
+    pub restitution: f32,
+    pub bounceThreshold: f32,
+    pub stiffness: f32,
+    pub damping: f32,
+    pub contactDistance: f32,
+    pub upper: f32,
+    pub lower: f32,
+}
+#[test] fn check_size_PxJointLinearLimitPair() { assert_eq!(std::mem::size_of::<PxJointLinearLimitPair>(), 28); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxJointAngularLimitPair {
+    pub restitution: f32,
+    pub bounceThreshold: f32,
+    pub stiffness: f32,
+    pub damping: f32,
+    pub contactDistance: f32,
+    pub upper: f32,
+    pub lower: f32,
+}
+#[test] fn check_size_PxJointAngularLimitPair() { assert_eq!(std::mem::size_of::<PxJointAngularLimitPair>(), 28); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxJointLimitCone {
+    pub restitution: f32,
+    pub bounceThreshold: f32,
+    pub stiffness: f32,
+    pub damping: f32,
+    pub contactDistance: f32,
+    pub yAngle: f32,
+    pub zAngle: f32,
+}
+#[test] fn check_size_PxJointLimitCone() { assert_eq!(std::mem::size_of::<PxJointLimitCone>(), 28); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxJointLimitPyramid {
+    pub restitution: f32,
+    pub bounceThreshold: f32,
+    pub stiffness: f32,
+    pub damping: f32,
+    pub contactDistance: f32,
+    pub yAngleMin: f32,
+    pub yAngleMax: f32,
+    pub zAngleMin: f32,
+    pub zAngleMax: f32,
+}
+#[test] fn check_size_PxJointLimitPyramid() { assert_eq!(std::mem::size_of::<PxJointLimitPyramid>(), 36); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxPrismaticJoint {
+    pub structgen_pad0: [u8; 8],
+    pub mConcreteType: u16,
+    pub mBaseFlags: PxBaseFlags,
+    pub structgen_pad1: [u8; 4],
+    pub userData: *mut std::ffi::c_void,
+}
+#[test] fn check_size_PxPrismaticJoint() { assert_eq!(std::mem::size_of::<PxPrismaticJoint>(), 24); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxRevoluteJoint {
+    pub structgen_pad0: [u8; 8],
+    pub mConcreteType: u16,
+    pub mBaseFlags: PxBaseFlags,
+    pub structgen_pad1: [u8; 4],
+    pub userData: *mut std::ffi::c_void,
+}
+#[test] fn check_size_PxRevoluteJoint() { assert_eq!(std::mem::size_of::<PxRevoluteJoint>(), 24); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxSphericalJoint {
+    pub structgen_pad0: [u8; 8],
+    pub mConcreteType: u16,
+    pub mBaseFlags: PxBaseFlags,
+    pub structgen_pad1: [u8; 4],
+    pub userData: *mut std::ffi::c_void,
+}
+#[test] fn check_size_PxSphericalJoint() { assert_eq!(std::mem::size_of::<PxSphericalJoint>(), 24); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxD6Joint {
+    pub structgen_pad0: [u8; 8],
+    pub mConcreteType: u16,
+    pub mBaseFlags: PxBaseFlags,
+    pub structgen_pad1: [u8; 4],
+    pub userData: *mut std::ffi::c_void,
+}
+#[test] fn check_size_PxD6Joint() { assert_eq!(std::mem::size_of::<PxD6Joint>(), 24); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxD6JointDrive {
+    pub stiffness: f32,
+    pub damping: f32,
+    pub forceLimit: f32,
+    pub flags: PxD6JointDriveFlags,
+}
+#[test] fn check_size_PxD6JointDrive() { assert_eq!(std::mem::size_of::<PxD6JointDrive>(), 16); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxGroupsMask {
+    pub bits0: u16,
+    pub bits1: u16,
+    pub bits2: u16,
+    pub bits3: u16,
+}
+#[test] fn check_size_PxGroupsMask() { assert_eq!(std::mem::size_of::<PxGroupsMask>(), 8); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxMassProperties {
+    pub inertiaTensor: PxMat33,
+    pub centerOfMass: PxVec3,
+    pub mass: f32,
+}
+#[test] fn check_size_PxMassProperties() { assert_eq!(std::mem::size_of::<PxMassProperties>(), 52); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxMeshOverlapUtil {
+    pub structgen_pad0: [u8; 1040],
+}
+#[test] fn check_size_PxMeshOverlapUtil() { assert_eq!(std::mem::size_of::<PxMeshOverlapUtil>(), 1040); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxSerialization_PxXmlMiscParameter {
+    pub upVector: PxVec3,
+    pub scale: PxTolerancesScale,
+}
+#[test] fn check_size_PxSerialization_PxXmlMiscParameter() { assert_eq!(std::mem::size_of::<PxSerialization_PxXmlMiscParameter>(), 20); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxSceneQueryHit {
+    pub actor: *mut PxRigidActor,
+    pub shape: *mut PxShape,
+    pub faceIndex: u32,
+    pub structgen_pad0: [u8; 4],
+}
+#[test] fn check_size_PxSceneQueryHit() { assert_eq!(std::mem::size_of::<PxSceneQueryHit>(), 24); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxSceneQueryFilterData {
+    pub data: PxFilterData,
+    pub flags: PxQueryFlags,
+    pub structgen_pad0: [u8; 2],
+}
+#[test] fn check_size_PxSceneQueryFilterData() { assert_eq!(std::mem::size_of::<PxSceneQueryFilterData>(), 20); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxSceneQueryCache {
+    pub shape: *mut PxShape,
+    pub actor: *mut PxRigidActor,
+    pub faceIndex: u32,
+    pub structgen_pad0: [u8; 4],
+}
+#[test] fn check_size_PxSceneQueryCache() { assert_eq!(std::mem::size_of::<PxSceneQueryCache>(), 24); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxRepXObject {
+    pub typeName: *const i8,
+    pub serializable: *const std::ffi::c_void,
+    pub id: usize,
+}
+#[test] fn check_size_PxRepXObject() { assert_eq!(std::mem::size_of::<PxRepXObject>(), 24); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxRepXInstantiationArgs {
+    pub structgen_pad0: [u8; 8],
+    pub cooker: *mut PxCooking,
+    pub stringTable: *mut PxStringTable,
+}
+#[test] fn check_size_PxRepXInstantiationArgs() { assert_eq!(std::mem::size_of::<PxRepXInstantiationArgs>(), 24); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleChassisData {
+    pub mMOI: PxVec3,
+    pub mMass: f32,
+    pub mCMOffset: PxVec3,
+    pub structgen_pad0: [u8; 4],
+}
+#[test] fn check_size_PxVehicleChassisData() { assert_eq!(std::mem::size_of::<PxVehicleChassisData>(), 32); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleEngineData {
+    pub mTorqueCurve: PxFixedSizeLookupTable_eMAX_NB_ENGINE_TORQUE_CURVE_ENTRIES_,
+    pub mMOI: f32,
+    pub mPeakTorque: f32,
+    pub mMaxOmega: f32,
+    pub mDampingRateFullThrottle: f32,
+    pub mDampingRateZeroThrottleClutchEngaged: f32,
+    pub mDampingRateZeroThrottleClutchDisengaged: f32,
+    pub structgen_pad0: [u8; 8],
+}
+#[test] fn check_size_PxVehicleEngineData() { assert_eq!(std::mem::size_of::<PxVehicleEngineData>(), 112); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleGearsData {
+    pub mRatios: [f32; 32],
+    pub mFinalRatio: f32,
+    pub mNbRatios: u32,
+    pub mSwitchTime: f32,
+    pub structgen_pad0: [u8; 4],
+}
+#[test] fn check_size_PxVehicleGearsData() { assert_eq!(std::mem::size_of::<PxVehicleGearsData>(), 144); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleAutoBoxData {
+    pub mUpRatios: [f32; 32],
+    pub mDownRatios: [f32; 32],
+}
+#[test] fn check_size_PxVehicleAutoBoxData() { assert_eq!(std::mem::size_of::<PxVehicleAutoBoxData>(), 256); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleDifferential4WData {
+    pub mFrontRearSplit: f32,
+    pub mFrontLeftRightSplit: f32,
+    pub mRearLeftRightSplit: f32,
+    pub mCentreBias: f32,
+    pub mFrontBias: f32,
+    pub mRearBias: f32,
+    pub mType: u32,
+    pub structgen_pad0: [u8; 4],
+}
+#[test] fn check_size_PxVehicleDifferential4WData() { assert_eq!(std::mem::size_of::<PxVehicleDifferential4WData>(), 32); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleDifferentialNWData {
+    pub structgen_pad0: [u8; 16],
+}
+#[test] fn check_size_PxVehicleDifferentialNWData() { assert_eq!(std::mem::size_of::<PxVehicleDifferentialNWData>(), 16); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleAckermannGeometryData {
+    pub mAccuracy: f32,
+    pub mFrontWidth: f32,
+    pub mRearWidth: f32,
+    pub mAxleSeparation: f32,
+}
+#[test] fn check_size_PxVehicleAckermannGeometryData() { assert_eq!(std::mem::size_of::<PxVehicleAckermannGeometryData>(), 16); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleClutchData {
+    pub mStrength: f32,
+    pub mAccuracyMode: u32,
+    pub mEstimateIterations: u32,
+    pub structgen_pad0: [u8; 4],
+}
+#[test] fn check_size_PxVehicleClutchData() { assert_eq!(std::mem::size_of::<PxVehicleClutchData>(), 16); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleTireLoadFilterData {
+    pub mMinNormalisedLoad: f32,
+    pub mMinFilteredNormalisedLoad: f32,
+    pub mMaxNormalisedLoad: f32,
+    pub mMaxFilteredNormalisedLoad: f32,
+    pub structgen_pad0: [u8; 16],
+}
+#[test] fn check_size_PxVehicleTireLoadFilterData() { assert_eq!(std::mem::size_of::<PxVehicleTireLoadFilterData>(), 32); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleWheelData {
+    pub mRadius: f32,
+    pub mWidth: f32,
+    pub mMass: f32,
+    pub mMOI: f32,
+    pub mDampingRate: f32,
+    pub mMaxBrakeTorque: f32,
+    pub mMaxHandBrakeTorque: f32,
+    pub mMaxSteer: f32,
+    pub mToeAngle: f32,
+    pub structgen_pad0: [u8; 12],
+}
+#[test] fn check_size_PxVehicleWheelData() { assert_eq!(std::mem::size_of::<PxVehicleWheelData>(), 48); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleSuspensionData {
+    pub mSpringStrength: f32,
+    pub mSpringDamperRate: f32,
+    pub mMaxCompression: f32,
+    pub mMaxDroop: f32,
+    pub mSprungMass: f32,
+    pub mCamberAtRest: f32,
+    pub mCamberAtMaxCompression: f32,
+    pub mCamberAtMaxDroop: f32,
+    pub structgen_pad0: [u8; 16],
+}
+#[test] fn check_size_PxVehicleSuspensionData() { assert_eq!(std::mem::size_of::<PxVehicleSuspensionData>(), 48); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleAntiRollBarData {
+    pub mWheel0: u32,
+    pub mWheel1: u32,
+    pub mStiffness: f32,
+    pub structgen_pad0: [u8; 4],
+}
+#[test] fn check_size_PxVehicleAntiRollBarData() { assert_eq!(std::mem::size_of::<PxVehicleAntiRollBarData>(), 16); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleTireData {
+    pub mLatStiffX: f32,
+    pub mLatStiffY: f32,
+    pub mLongitudinalStiffnessPerUnitGravity: f32,
+    pub mCamberStiffnessPerUnitGravity: f32,
+    pub mFrictionVsSlipGraph: [[f32; 2]; 3],
+    pub mType: u32,
+    pub structgen_pad0: [u8; 20],
+}
+#[test] fn check_size_PxVehicleTireData() { assert_eq!(std::mem::size_of::<PxVehicleTireData>(), 64); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleWheelsSimData {
+    pub structgen_pad0: [u8; 96],
+}
+#[test] fn check_size_PxVehicleWheelsSimData() { assert_eq!(std::mem::size_of::<PxVehicleWheelsSimData>(), 96); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleWheelsDynData {
+    pub structgen_pad0: [u8; 48],
+}
+#[test] fn check_size_PxVehicleWheelsDynData() { assert_eq!(std::mem::size_of::<PxVehicleWheelsDynData>(), 48); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleWheels {
+    pub structgen_pad0: [u8; 8],
+    pub mConcreteType: u16,
+    pub mBaseFlags: PxBaseFlags,
+    pub structgen_pad1: [u8; 4],
+    pub mWheelsSimData: PxVehicleWheelsSimData,
+    pub mWheelsDynData: PxVehicleWheelsDynData,
+    pub mActor: *mut PxRigidDynamic,
+    pub structgen_pad2: [u8; 5],
+    pub mType: u8,
+    pub mPad0: [u8; 14],
+    pub structgen_pad3: [u8; 4],
+}
+#[test] fn check_size_PxVehicleWheels() { assert_eq!(std::mem::size_of::<PxVehicleWheels>(), 192); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleDriveSimData {
+    pub mEngine: PxVehicleEngineData,
+    pub mGears: PxVehicleGearsData,
+    pub mClutch: PxVehicleClutchData,
+    pub mAutoBox: PxVehicleAutoBoxData,
+}
+#[test] fn check_size_PxVehicleDriveSimData() { assert_eq!(std::mem::size_of::<PxVehicleDriveSimData>(), 528); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleDriveDynData {
+    pub mControlAnalogVals: [f32; 16],
+    pub mUseAutoGears: bool,
+    pub mGearUpPressed: bool,
+    pub mGearDownPressed: bool,
+    pub structgen_pad0: [u8; 1],
+    pub mCurrentGear: u32,
+    pub mTargetGear: u32,
+    pub mEnginespeed: f32,
+    pub mGearSwitchTime: f32,
+    pub mAutoBoxSwitchTime: f32,
+    pub structgen_pad1: [u8; 8],
+}
+#[test] fn check_size_PxVehicleDriveDynData() { assert_eq!(std::mem::size_of::<PxVehicleDriveDynData>(), 96); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleDrive {
+    pub structgen_pad0: [u8; 8],
+    pub mConcreteType: u16,
+    pub mBaseFlags: PxBaseFlags,
+    pub structgen_pad1: [u8; 4],
+    pub mWheelsSimData: PxVehicleWheelsSimData,
+    pub mWheelsDynData: PxVehicleWheelsDynData,
+    pub mActor: *mut PxRigidDynamic,
+    pub structgen_pad2: [u8; 5],
+    pub mType: u8,
+    pub mPad0: [u8; 14],
+    pub mDriveDynData: PxVehicleDriveDynData,
+    pub structgen_pad3: [u8; 4],
+}
+#[test] fn check_size_PxVehicleDrive() { assert_eq!(std::mem::size_of::<PxVehicleDrive>(), 288); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleDriveSimData4W {
+    pub mEngine: PxVehicleEngineData,
+    pub mGears: PxVehicleGearsData,
+    pub mClutch: PxVehicleClutchData,
+    pub mAutoBox: PxVehicleAutoBoxData,
+    pub structgen_pad0: [u8; 48],
+}
+#[test] fn check_size_PxVehicleDriveSimData4W() { assert_eq!(std::mem::size_of::<PxVehicleDriveSimData4W>(), 576); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleDrive4W {
+    pub structgen_pad0: [u8; 8],
+    pub mConcreteType: u16,
+    pub mBaseFlags: PxBaseFlags,
+    pub structgen_pad1: [u8; 4],
+    pub mWheelsSimData: PxVehicleWheelsSimData,
+    pub mWheelsDynData: PxVehicleWheelsDynData,
+    pub mActor: *mut PxRigidDynamic,
+    pub structgen_pad2: [u8; 5],
+    pub mType: u8,
+    pub mPad0: [u8; 14],
+    pub mDriveDynData: PxVehicleDriveDynData,
+    pub mDriveSimData: PxVehicleDriveSimData4W,
+    pub structgen_pad3: [u8; 4],
+}
+#[test] fn check_size_PxVehicleDrive4W() { assert_eq!(std::mem::size_of::<PxVehicleDrive4W>(), 864); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleDriveTank {
+    pub structgen_pad0: [u8; 8],
+    pub mConcreteType: u16,
+    pub mBaseFlags: PxBaseFlags,
+    pub structgen_pad1: [u8; 4],
+    pub mWheelsSimData: PxVehicleWheelsSimData,
+    pub mWheelsDynData: PxVehicleWheelsDynData,
+    pub mActor: *mut PxRigidDynamic,
+    pub structgen_pad2: [u8; 5],
+    pub mType: u8,
+    pub mPad0: [u8; 14],
+    pub mDriveDynData: PxVehicleDriveDynData,
+    pub mDriveSimData: PxVehicleDriveSimData,
+    pub structgen_pad3: [u8; 20],
+}
+#[test] fn check_size_PxVehicleDriveTank() { assert_eq!(std::mem::size_of::<PxVehicleDriveTank>(), 832); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleDrivableSurfaceType {
+    pub mType: u32,
+}
+#[test] fn check_size_PxVehicleDrivableSurfaceType() { assert_eq!(std::mem::size_of::<PxVehicleDrivableSurfaceType>(), 4); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleDrivableSurfaceToTireFrictionPairs {
+    pub structgen_pad0: [u8; 48],
+}
+#[test] fn check_size_PxVehicleDrivableSurfaceToTireFrictionPairs() { assert_eq!(std::mem::size_of::<PxVehicleDrivableSurfaceToTireFrictionPairs>(), 48); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxWheelQueryResult {
+    pub suspLineStart: PxVec3,
+    pub suspLineDir: PxVec3,
+    pub suspLineLength: f32,
+    pub isInAir: bool,
+    pub structgen_pad0: [u8; 3],
+    pub tireContactActor: *mut PxActor,
+    pub tireContactShape: *mut PxShape,
+    pub tireSurfaceMaterial: *const PxMaterial,
+    pub tireSurfaceType: u32,
+    pub tireContactPoint: PxVec3,
+    pub tireContactNormal: PxVec3,
+    pub tireFriction: f32,
+    pub suspJounce: f32,
+    pub suspSpringForce: f32,
+    pub tireLongitudinalDir: PxVec3,
+    pub tireLateralDir: PxVec3,
+    pub longitudinalSlip: f32,
+    pub lateralSlip: f32,
+    pub steerAngle: f32,
+    pub localPose: PxTransform,
+}
+#[test] fn check_size_PxWheelQueryResult() { assert_eq!(std::mem::size_of::<PxWheelQueryResult>(), 160); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleWheelConcurrentUpdateData {
+    pub structgen_pad0: [u8; 64],
+}
+#[test] fn check_size_PxVehicleWheelConcurrentUpdateData() { assert_eq!(std::mem::size_of::<PxVehicleWheelConcurrentUpdateData>(), 64); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleConcurrentUpdateData {
+    pub concurrentWheelUpdates: *mut PxVehicleWheelConcurrentUpdateData,
+    pub nbConcurrentWheelUpdates: u32,
+    pub structgen_pad0: [u8; 28],
+}
+#[test] fn check_size_PxVehicleConcurrentUpdateData() { assert_eq!(std::mem::size_of::<PxVehicleConcurrentUpdateData>(), 40); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleWheelQueryResult {
+    pub wheelQueryResults: *mut PxWheelQueryResult,
+    pub nbWheelQueryResults: u32,
+    pub structgen_pad0: [u8; 4],
+}
+#[test] fn check_size_PxVehicleWheelQueryResult() { assert_eq!(std::mem::size_of::<PxVehicleWheelQueryResult>(), 16); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleGraph {
+    pub structgen_pad0: [u8; 15840],
+}
+#[test] fn check_size_PxVehicleGraph() { assert_eq!(std::mem::size_of::<PxVehicleGraph>(), 15840); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleTelemetryData {
+    pub structgen_pad0: [u8; 48],
+}
+#[test] fn check_size_PxVehicleTelemetryData() { assert_eq!(std::mem::size_of::<PxVehicleTelemetryData>(), 48); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleDriveSimDataNW {
+    pub mEngine: PxVehicleEngineData,
+    pub mGears: PxVehicleGearsData,
+    pub mClutch: PxVehicleClutchData,
+    pub mAutoBox: PxVehicleAutoBoxData,
+    pub structgen_pad0: [u8; 16],
+}
+#[test] fn check_size_PxVehicleDriveSimDataNW() { assert_eq!(std::mem::size_of::<PxVehicleDriveSimDataNW>(), 544); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleDriveNW {
+    pub structgen_pad0: [u8; 8],
+    pub mConcreteType: u16,
+    pub mBaseFlags: PxBaseFlags,
+    pub structgen_pad1: [u8; 4],
+    pub mWheelsSimData: PxVehicleWheelsSimData,
+    pub mWheelsDynData: PxVehicleWheelsDynData,
+    pub mActor: *mut PxRigidDynamic,
+    pub structgen_pad2: [u8; 5],
+    pub mType: u8,
+    pub mPad0: [u8; 14],
+    pub mDriveDynData: PxVehicleDriveDynData,
+    pub mDriveSimData: PxVehicleDriveSimDataNW,
+    pub structgen_pad3: [u8; 4],
+}
+#[test] fn check_size_PxVehicleDriveNW() { assert_eq!(std::mem::size_of::<PxVehicleDriveNW>(), 832); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleDrive4WRawInputData {
+    pub structgen_pad0: [u8; 40],
+}
+#[test] fn check_size_PxVehicleDrive4WRawInputData() { assert_eq!(std::mem::size_of::<PxVehicleDrive4WRawInputData>(), 40); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleKeySmoothingData {
+    pub mRiseRates: [f32; 16],
+    pub mFallRates: [f32; 16],
+}
+#[test] fn check_size_PxVehicleKeySmoothingData() { assert_eq!(std::mem::size_of::<PxVehicleKeySmoothingData>(), 128); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehiclePadSmoothingData {
+    pub mRiseRates: [f32; 16],
+    pub mFallRates: [f32; 16],
+}
+#[test] fn check_size_PxVehiclePadSmoothingData() { assert_eq!(std::mem::size_of::<PxVehiclePadSmoothingData>(), 128); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleDriveNWRawInputData {
+    pub structgen_pad0: [u8; 40],
+}
+#[test] fn check_size_PxVehicleDriveNWRawInputData() { assert_eq!(std::mem::size_of::<PxVehicleDriveNWRawInputData>(), 40); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleDriveTankRawInputData {
+    pub structgen_pad0: [u8; 32],
+}
+#[test] fn check_size_PxVehicleDriveTankRawInputData() { assert_eq!(std::mem::size_of::<PxVehicleDriveTankRawInputData>(), 32); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleCopyDynamicsMap {
+    pub sourceWheelIds: [u8; 20],
+    pub targetWheelIds: [u8; 20],
+}
+#[test] fn check_size_PxVehicleCopyDynamicsMap() { assert_eq!(std::mem::size_of::<PxVehicleCopyDynamicsMap>(), 40); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleGraphChannelDesc {
+    pub mMinY: f32,
+    pub mMaxY: f32,
+    pub mMidY: f32,
+    pub mColorLow: PxVec3,
+    pub mColorHigh: PxVec3,
+    pub structgen_pad0: [u8; 4],
+    pub mTitle: *mut i8,
+}
+#[test] fn check_size_PxVehicleGraphChannelDesc() { assert_eq!(std::mem::size_of::<PxVehicleGraphChannelDesc>(), 48); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleGraphDesc {
+    pub structgen_pad0: [u8; 32],
+}
+#[test] fn check_size_PxVehicleGraphDesc() { assert_eq!(std::mem::size_of::<PxVehicleGraphDesc>(), 32); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleNoDrive {
+    pub structgen_pad0: [u8; 8],
+    pub mConcreteType: u16,
+    pub mBaseFlags: PxBaseFlags,
+    pub structgen_pad1: [u8; 4],
+    pub mWheelsSimData: PxVehicleWheelsSimData,
+    pub mWheelsDynData: PxVehicleWheelsDynData,
+    pub mActor: *mut PxRigidDynamic,
+    pub structgen_pad2: [u8; 5],
+    pub mType: u8,
+    pub mPad0: [u8; 14],
+    pub structgen_pad3: [u8; 36],
+}
+#[test] fn check_size_PxVehicleNoDrive() { assert_eq!(std::mem::size_of::<PxVehicleNoDrive>(), 224); }
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxProfileScoped {
+    pub mCallback: *mut PxProfilerCallback,
+    pub mEventName: *const i8,
+    pub mProfilerData: *mut std::ffi::c_void,
+    pub mContextId: usize,
+    pub mDetached: bool,
+    pub structgen_pad0: [u8; 7],
+}
+#[test] fn check_size_PxProfileScoped() { assert_eq!(std::mem::size_of::<PxProfileScoped>(), 40); }

--- a/physx-sys/src/generated/aarch64-apple-darwin/structgen_out.hpp
+++ b/physx-sys/src/generated/aarch64-apple-darwin/structgen_out.hpp
@@ -1,0 +1,1814 @@
+struct physx_PxAllocatorCallback_Pod {
+    void* vtable_;
+};
+struct physx_PxAssertHandler_Pod {
+    void* vtable_;
+};
+struct physx_PxVec3_Pod {
+    float x;
+    float y;
+    float z;
+};
+struct physx_PxQuat_Pod {
+    float x;
+    float y;
+    float z;
+    float w;
+};
+struct physx_PxMat33_Pod {
+    physx_PxVec3_Pod column0;
+    physx_PxVec3_Pod column1;
+    physx_PxVec3_Pod column2;
+};
+struct physx_PxPlane_Pod {
+    physx_PxVec3_Pod n;
+    float d;
+};
+struct physx_PxTransform_Pod {
+    physx_PxQuat_Pod q;
+    physx_PxVec3_Pod p;
+};
+struct physx_PxVec4_Pod {
+    float x;
+    float y;
+    float z;
+    float w;
+};
+struct physx_PxMat44_Pod {
+    physx_PxVec4_Pod column0;
+    physx_PxVec4_Pod column1;
+    physx_PxVec4_Pod column2;
+    physx_PxVec4_Pod column3;
+};
+struct physx_PxBounds3_Pod {
+    physx_PxVec3_Pod minimum;
+    physx_PxVec3_Pod maximum;
+};
+struct physx_PxErrorCallback_Pod {
+    void* vtable_;
+};
+struct physx_PxInputStream_Pod {
+    void* vtable_;
+};
+struct physx_PxInputData_Pod {
+    void* vtable_;
+};
+struct physx_PxOutputStream_Pod {
+    void* vtable_;
+};
+struct physx_PxVec2_Pod {
+    float x;
+    float y;
+};
+struct physx_PxStridedData_Pod {
+    uint32_t stride;
+    char structgen_pad0[4];
+    void* data;
+};
+struct physx_PxBoundedData_Pod {
+    uint32_t stride;
+    char structgen_pad0[4];
+    void* data;
+    uint32_t count;
+    char structgen_pad1[4];
+};
+struct physx_PxDebugPoint_Pod {
+    physx_PxVec3_Pod pos;
+    uint32_t color;
+};
+struct physx_PxDebugLine_Pod {
+    physx_PxVec3_Pod pos0;
+    uint32_t color0;
+    physx_PxVec3_Pod pos1;
+    uint32_t color1;
+};
+struct physx_PxDebugTriangle_Pod {
+    physx_PxVec3_Pod pos0;
+    uint32_t color0;
+    physx_PxVec3_Pod pos1;
+    uint32_t color1;
+    physx_PxVec3_Pod pos2;
+    uint32_t color2;
+};
+struct physx_PxDebugText_Pod {
+    physx_PxVec3_Pod position;
+    float size;
+    uint32_t color;
+    char structgen_pad0[4];
+    char* string;
+};
+struct physx_PxRenderBuffer_Pod {
+    void* vtable_;
+};
+struct physx_PxProcessPxBaseCallback_Pod {
+    void* vtable_;
+};
+struct physx_PxBaseFlags_Pod {
+    uint16_t mBits;
+};
+struct physx_PxBase_Pod {
+    char structgen_pad0[8];
+    uint16_t mConcreteType;
+    physx_PxBaseFlags_Pod mBaseFlags;
+    char structgen_pad1[4];
+};
+struct physx_PxSerializationContext_Pod {
+    void* vtable_;
+};
+struct physx_PxCollection_Pod {
+    void* vtable_;
+};
+struct physx_PxDeserializationContext_Pod {
+    char structgen_pad0[8];
+    unsigned char* mExtraDataAddress;
+};
+struct physx_PxSerializationRegistry_Pod {
+    void* vtable_;
+};
+struct physx_PxSerializer_Pod {
+    void* vtable_;
+};
+struct physx_PxRepXSerializer_Pod {
+    void* vtable_;
+};
+struct physx_PxTolerancesScale_Pod {
+    float length;
+    float speed;
+};
+struct physx_PxStringTable_Pod {
+    void* vtable_;
+};
+struct physx_PxFoundation_Pod {
+    void* vtable_;
+};
+struct physx_PxProfilerCallback_Pod {
+    void* vtable_;
+};
+struct physx_PxPhysicsInsertionCallback_Pod {
+    void* vtable_;
+};
+struct physx_PxTaskManager_Pod {
+    void* vtable_;
+};
+struct physx_PxCpuDispatcher_Pod {
+    void* vtable_;
+};
+struct physx_PxTask_Pod {
+    char structgen_pad0[8];
+    uint64_t mContextID;
+    physx_PxTaskManager_Pod* mTm;
+    uint32_t mTaskID;
+    char structgen_pad1[4];
+};
+struct physx_PxBaseTask_Pod {
+    char structgen_pad0[8];
+    uint64_t mContextID;
+    physx_PxTaskManager_Pod* mTm;
+};
+struct physx_PxLightCpuTask_Pod {
+    char structgen_pad0[8];
+    uint64_t mContextID;
+    physx_PxTaskManager_Pod* mTm;
+    physx_PxBaseTask_Pod* mCont;
+    int32_t mRefCount;
+    char structgen_pad1[4];
+};
+struct physx_PxGeometry_Pod {
+    int mType;
+};
+struct physx_PxBoxGeometry_Pod {
+    int mType;
+    physx_PxVec3_Pod halfExtents;
+};
+struct physx_PxBVHStructure_Pod {
+    char structgen_pad0[8];
+    uint16_t mConcreteType;
+    physx_PxBaseFlags_Pod mBaseFlags;
+    char structgen_pad1[4];
+};
+struct physx_PxCapsuleGeometry_Pod {
+    int mType;
+    float radius;
+    float halfHeight;
+};
+struct physx_PxConvexMesh_Pod {
+    char structgen_pad0[8];
+    uint16_t mConcreteType;
+    physx_PxBaseFlags_Pod mBaseFlags;
+    char structgen_pad1[4];
+};
+struct physx_PxHullPolygon_Pod {
+    float mPlane[4];
+    uint16_t mNbVerts;
+    uint16_t mIndexBase;
+};
+struct physx_PxMeshScale_Pod {
+    physx_PxVec3_Pod scale;
+    physx_PxQuat_Pod rotation;
+};
+struct physx_PxConvexMeshGeometryFlags_Pod {
+    unsigned char mBits;
+};
+struct PxPadding_3__Pod {
+    unsigned char mPadding[3];
+};
+struct physx_PxConvexMeshGeometry_Pod {
+    int mType;
+    physx_PxMeshScale_Pod scale;
+    physx_PxConvexMesh_Pod* convexMesh;
+    physx_PxConvexMeshGeometryFlags_Pod meshFlags;
+    PxPadding_3__Pod paddingFromFlags;
+    char structgen_pad0[4];
+};
+struct physx_PxSphereGeometry_Pod {
+    int mType;
+    float radius;
+};
+struct physx_PxPlaneGeometry_Pod {
+    int mType;
+};
+struct physx_PxMeshGeometryFlags_Pod {
+    unsigned char mBits;
+};
+struct physx_PxTriangleMesh_Pod {
+    char structgen_pad0[8];
+    uint16_t mConcreteType;
+    physx_PxBaseFlags_Pod mBaseFlags;
+    char structgen_pad1[4];
+};
+struct physx_PxTriangleMeshGeometry_Pod {
+    int mType;
+    physx_PxMeshScale_Pod scale;
+    physx_PxMeshGeometryFlags_Pod meshFlags;
+    PxPadding_3__Pod paddingFromFlags;
+    char structgen_pad0[4];
+    physx_PxTriangleMesh_Pod* triangleMesh;
+};
+struct physx_PxHeightField_Pod {
+    char structgen_pad0[8];
+    uint16_t mConcreteType;
+    physx_PxBaseFlags_Pod mBaseFlags;
+    char structgen_pad1[4];
+};
+struct physx_PxHeightFieldGeometry_Pod {
+    int mType;
+    char structgen_pad0[4];
+    physx_PxHeightField_Pod* heightField;
+    float heightScale;
+    float rowScale;
+    float columnScale;
+    physx_PxMeshGeometryFlags_Pod heightFieldFlags;
+    PxPadding_3__Pod paddingFromFlags;
+};
+struct Anonymous59_Pod {
+    unsigned char geometry[4];
+    unsigned char box[16];
+    unsigned char sphere[8];
+    unsigned char capsule[12];
+    unsigned char plane[4];
+    unsigned char convex[48];
+    unsigned char mesh[48];
+    unsigned char heightfield[32];
+};
+struct physx_PxGeometryHolder_Pod {
+    char structgen_pad0[48];
+};
+struct physx_PxRigidActor_Pod {
+    char structgen_pad0[8];
+    uint16_t mConcreteType;
+    physx_PxBaseFlags_Pod mBaseFlags;
+    char structgen_pad1[4];
+    void* userData;
+};
+struct physx_PxShape_Pod {
+    char structgen_pad0[8];
+    uint16_t mConcreteType;
+    physx_PxBaseFlags_Pod mBaseFlags;
+    char structgen_pad1[4];
+    void* userData;
+};
+struct physx_PxActorShape_Pod {
+    physx_PxRigidActor_Pod* actor;
+    physx_PxShape_Pod* shape;
+};
+struct physx_PxQueryHit_Pod {
+    physx_PxRigidActor_Pod* actor;
+    physx_PxShape_Pod* shape;
+    uint32_t faceIndex;
+    char structgen_pad0[4];
+};
+struct physx_PxHitFlags_Pod {
+    uint16_t mBits;
+};
+struct physx_PxLocationHit_Pod {
+    physx_PxRigidActor_Pod* actor;
+    physx_PxShape_Pod* shape;
+    uint32_t faceIndex;
+    physx_PxHitFlags_Pod flags;
+    char structgen_pad0[2];
+    physx_PxVec3_Pod position;
+    physx_PxVec3_Pod normal;
+    float distance;
+    char structgen_pad1[4];
+};
+struct physx_PxRaycastHit_Pod {
+    physx_PxRigidActor_Pod* actor;
+    physx_PxShape_Pod* shape;
+    uint32_t faceIndex;
+    physx_PxHitFlags_Pod flags;
+    char structgen_pad0[2];
+    physx_PxVec3_Pod position;
+    physx_PxVec3_Pod normal;
+    float distance;
+    float u;
+    float v;
+    char structgen_pad1[4];
+};
+struct physx_PxSweepHit_Pod {
+    physx_PxRigidActor_Pod* actor;
+    physx_PxShape_Pod* shape;
+    uint32_t faceIndex;
+    physx_PxHitFlags_Pod flags;
+    char structgen_pad0[2];
+    physx_PxVec3_Pod position;
+    physx_PxVec3_Pod normal;
+    float distance;
+    uint32_t padTo16Bytes;
+};
+struct physx_PxBitAndByte_Pod {
+    unsigned char mData;
+};
+struct physx_PxHeightFieldSample_Pod {
+    int16_t height;
+    physx_PxBitAndByte_Pod materialIndex0;
+    physx_PxBitAndByte_Pod materialIndex1;
+};
+struct physx_PxHeightFieldFlags_Pod {
+    uint16_t mBits;
+};
+struct physx_PxHeightFieldDesc_Pod {
+    uint32_t nbRows;
+    uint32_t nbColumns;
+    unsigned int format;
+    char structgen_pad0[4];
+    physx_PxStridedData_Pod samples;
+    float convexEdgeThreshold;
+    physx_PxHeightFieldFlags_Pod flags;
+    char structgen_pad1[2];
+};
+struct physx_PxTriangle_Pod {
+    physx_PxVec3_Pod verts[3];
+};
+struct physx_PxMeshFlags_Pod {
+    uint16_t mBits;
+};
+struct physx_PxSimpleTriangleMesh_Pod {
+    physx_PxBoundedData_Pod points;
+    physx_PxBoundedData_Pod triangles;
+    physx_PxMeshFlags_Pod flags;
+    char structgen_pad0[6];
+};
+struct physx_PxTriangleMeshFlags_Pod {
+    unsigned char mBits;
+};
+struct physx_PxActor_Pod {
+    char structgen_pad0[8];
+    uint16_t mConcreteType;
+    physx_PxBaseFlags_Pod mBaseFlags;
+    char structgen_pad1[4];
+    void* userData;
+};
+struct physx_PxScene_Pod {
+    char structgen_pad0[8];
+    void* userData;
+};
+struct physx_PxActorFlags_Pod {
+    unsigned char mBits;
+};
+struct physx_PxAggregate_Pod {
+    char structgen_pad0[8];
+    uint16_t mConcreteType;
+    physx_PxBaseFlags_Pod mBaseFlags;
+    char structgen_pad1[4];
+};
+struct physx_PxArticulationBase_Pod {
+    char structgen_pad0[8];
+    uint16_t mConcreteType;
+    physx_PxBaseFlags_Pod mBaseFlags;
+    char structgen_pad1[4];
+    void* userData;
+};
+struct physx_PxArticulationLink_Pod {
+    char structgen_pad0[8];
+    uint16_t mConcreteType;
+    physx_PxBaseFlags_Pod mBaseFlags;
+    char structgen_pad1[4];
+    void* userData;
+};
+struct physx_PxArticulationImpl_Pod;
+struct physx_PxArticulationJointBase_Pod {
+    char structgen_pad0[8];
+    uint16_t mConcreteType;
+    physx_PxBaseFlags_Pod mBaseFlags;
+    char structgen_pad1[4];
+};
+struct physx_PxArticulation_Pod {
+    char structgen_pad0[8];
+    uint16_t mConcreteType;
+    physx_PxBaseFlags_Pod mBaseFlags;
+    char structgen_pad1[4];
+    void* userData;
+};
+struct physx_PxArticulationDriveCache_Pod {
+    char structgen_pad0[1];
+};
+struct physx_PxConstraintInvMassScale_Pod {
+    float linear0;
+    float angular0;
+    float linear1;
+    float angular1;
+};
+struct physx_PxConstraintVisualizer_Pod {
+    void* vtable_;
+};
+struct physx_PxConstraintConnector_Pod {
+    void* vtable_;
+};
+struct physx_pvdsdk_PvdDataStream_Pod;
+struct physx_PxConstraint_Pod {
+    char structgen_pad0[8];
+    uint16_t mConcreteType;
+    physx_PxBaseFlags_Pod mBaseFlags;
+    char structgen_pad1[4];
+};
+struct physx_PxSolverBody_Pod {
+    physx_PxVec3_Pod linearVelocity;
+    uint16_t maxSolverNormalProgress;
+    uint16_t maxSolverFrictionProgress;
+    physx_PxVec3_Pod angularState;
+    uint32_t solverProgress;
+};
+struct physx_PxSolverBodyData_Pod {
+    physx_PxVec3_Pod linearVelocity;
+    float invMass;
+    physx_PxVec3_Pod angularVelocity;
+    float reportThreshold;
+    physx_PxMat33_Pod sqrtInvInertia;
+    float penBiasClamp;
+    uint32_t nodeIndex;
+    float maxContactImpulse;
+    physx_PxTransform_Pod body2World;
+    uint16_t lockFlags;
+    uint16_t pad;
+};
+struct physx_PxConstraintAllocator_Pod {
+    void* vtable_;
+};
+struct physx_PxTGSSolverBodyVel_Pod {
+    physx_PxVec3_Pod linearVelocity;
+    uint16_t nbStaticInteractions;
+    uint16_t maxDynamicPartition;
+    physx_PxVec3_Pod angularVelocity;
+    uint32_t partitionMask;
+    physx_PxVec3_Pod deltaAngDt;
+    float maxAngVel;
+    physx_PxVec3_Pod deltaLinDt;
+    uint16_t lockFlags;
+    bool isKinematic;
+    unsigned char pad;
+};
+struct physx_PxTGSSolverBodyData_Pod {
+    physx_PxVec3_Pod originalLinearVelocity;
+    float maxContactImpulse;
+    physx_PxVec3_Pod originalAngularVelocity;
+    float penBiasClamp;
+    float invMass;
+    uint32_t nodeIndex;
+    float reportThreshold;
+    uint32_t pad;
+};
+struct physx_PxSpatialForce_Pod {
+    physx_PxVec3_Pod force;
+    float pad0;
+    physx_PxVec3_Pod torque;
+    float pad1;
+};
+struct physx_PxArticulationRootLinkData_Pod {
+    physx_PxTransform_Pod transform;
+    physx_PxVec3_Pod worldLinVel;
+    physx_PxVec3_Pod worldAngVel;
+    physx_PxVec3_Pod worldLinAccel;
+    physx_PxVec3_Pod worldAngAccel;
+};
+struct physx_PxArticulationCache_Pod {
+    physx_PxSpatialForce_Pod* externalForces;
+    float* denseJacobian;
+    float* massMatrix;
+    float* jointVelocity;
+    float* jointAcceleration;
+    float* jointPosition;
+    float* jointForce;
+    char structgen_pad0[16];
+    physx_PxArticulationRootLinkData_Pod* rootLinkData;
+    float* coefficientMatrix;
+    float* lambda;
+    void* scratchMemory;
+    void* scratchAllocator;
+    uint32_t version;
+    char structgen_pad1[4];
+};
+struct physx_PxArticulationReducedCoordinate_Pod {
+    char structgen_pad0[8];
+    uint16_t mConcreteType;
+    physx_PxBaseFlags_Pod mBaseFlags;
+    char structgen_pad1[4];
+    void* userData;
+};
+struct physx_PxArticulationFlags_Pod {
+    unsigned char mBits;
+};
+struct physx_PxArticulationCacheFlags_Pod {
+    unsigned char mBits;
+};
+struct physx_PxJoint_Pod {
+    char structgen_pad0[8];
+    uint16_t mConcreteType;
+    physx_PxBaseFlags_Pod mBaseFlags;
+    char structgen_pad1[4];
+    void* userData;
+};
+struct physx_PxArticulationJointImpl_Pod;
+struct physx_PxArticulationJoint_Pod {
+    char structgen_pad0[8];
+    uint16_t mConcreteType;
+    physx_PxBaseFlags_Pod mBaseFlags;
+    char structgen_pad1[4];
+};
+struct physx_PxArticulationJointReducedCoordinate_Pod {
+    char structgen_pad0[8];
+    uint16_t mConcreteType;
+    physx_PxBaseFlags_Pod mBaseFlags;
+    char structgen_pad1[4];
+};
+struct physx_PxFilterData_Pod {
+    uint32_t word0;
+    uint32_t word1;
+    uint32_t word2;
+    uint32_t word3;
+};
+struct physx_PxMaterial_Pod {
+    char structgen_pad0[8];
+    uint16_t mConcreteType;
+    physx_PxBaseFlags_Pod mBaseFlags;
+    char structgen_pad1[4];
+    void* userData;
+};
+struct physx_PxShapeFlags_Pod {
+    unsigned char mBits;
+};
+struct physx_PxRigidBody_Pod {
+    char structgen_pad0[8];
+    uint16_t mConcreteType;
+    physx_PxBaseFlags_Pod mBaseFlags;
+    char structgen_pad1[4];
+    void* userData;
+};
+struct physx_PxRigidBodyFlags_Pod {
+    unsigned char mBits;
+};
+struct physx_PxFilterFlags_Pod {
+    uint16_t mBits;
+};
+struct physx_PxSimulationFilterCallback_Pod {
+    void* vtable_;
+};
+struct physx_PxPairFlags_Pod {
+    uint16_t mBits;
+};
+struct physx_PxQueryFlags_Pod {
+    uint16_t mBits;
+};
+struct physx_PxQueryFilterData_Pod {
+    physx_PxFilterData_Pod data;
+    physx_PxQueryFlags_Pod flags;
+    char structgen_pad0[2];
+};
+struct physx_PxQueryFilterCallback_Pod {
+    void* vtable_;
+};
+struct physx_PxRaycastQueryResult_Pod;
+struct physx_PxSweepQueryResult_Pod;
+struct physx_PxOverlapQueryResult_Pod;
+struct physx_PxOverlapHit_Pod {
+    physx_PxRigidActor_Pod* actor;
+    physx_PxShape_Pod* shape;
+    uint32_t faceIndex;
+    uint32_t padTo16Bytes;
+};
+struct physx_PxBatchQueryMemory_Pod {
+    physx_PxRaycastQueryResult_Pod* userRaycastResultBuffer;
+    physx_PxRaycastHit_Pod* userRaycastTouchBuffer;
+    physx_PxSweepQueryResult_Pod* userSweepResultBuffer;
+    physx_PxSweepHit_Pod* userSweepTouchBuffer;
+    physx_PxOverlapQueryResult_Pod* userOverlapResultBuffer;
+    physx_PxOverlapHit_Pod* userOverlapTouchBuffer;
+    uint32_t raycastTouchBufferSize;
+    uint32_t sweepTouchBufferSize;
+    uint32_t overlapTouchBufferSize;
+    uint32_t raycastResultBufferSize;
+    uint32_t sweepResultBufferSize;
+    uint32_t overlapResultBufferSize;
+};
+struct physx_PxBatchQueryDesc_Pod {
+    void* filterShaderData;
+    uint32_t filterShaderDataSize;
+    char structgen_pad0[4];
+    void* preFilterShader;
+    void* postFilterShader;
+    physx_PxBatchQueryMemory_Pod queryMemory;
+};
+struct physx_PxBatchQuery_Pod {
+    void* vtable_;
+};
+struct physx_PxQueryCache_Pod {
+    physx_PxShape_Pod* shape;
+    physx_PxRigidActor_Pod* actor;
+    uint32_t faceIndex;
+    char structgen_pad0[4];
+};
+struct physx_PxConstraintFlags_Pod {
+    uint16_t mBits;
+};
+struct physx_PxConstraintShaderTable_Pod {
+    void* solverPrep;
+    void* project;
+    void* visualize;
+    unsigned int flag;
+    char structgen_pad0[4];
+};
+struct physx_PxMassModificationProps_Pod {
+    float mInvMassScale0;
+    float mInvInertiaScale0;
+    float mInvMassScale1;
+    float mInvInertiaScale1;
+};
+struct physx_PxContactPatch_Pod {
+    physx_PxMassModificationProps_Pod mMassModification;
+    physx_PxVec3_Pod normal;
+    float restitution;
+    float dynamicFriction;
+    float staticFriction;
+    unsigned char startContactIndex;
+    unsigned char nbContacts;
+    unsigned char materialFlags;
+    unsigned char internalFlags;
+    uint16_t materialIndex0;
+    uint16_t materialIndex1;
+};
+struct physx_PxContact_Pod {
+    physx_PxVec3_Pod contact;
+    float separation;
+};
+struct physx_PxContactStreamIterator_Pod {
+    physx_PxVec3_Pod zero;
+    char structgen_pad0[4];
+    physx_PxContactPatch_Pod* patch;
+    physx_PxContact_Pod* contact;
+    uint32_t* faceIndice;
+    uint32_t totalPatches;
+    uint32_t totalContacts;
+    uint32_t nextContactIndex;
+    uint32_t nextPatchIndex;
+    uint32_t contactPatchHeaderSize;
+    uint32_t contactPointSize;
+    unsigned int mStreamFormat;
+    uint32_t forceNoResponse;
+    bool pointStepped;
+    char structgen_pad1[3];
+    uint32_t hasFaceIndices;
+};
+struct physx_PxModifiableContact_Pod {
+    physx_PxVec3_Pod contact;
+    float separation;
+    physx_PxVec3_Pod targetVelocity;
+    float maxImpulse;
+    physx_PxVec3_Pod normal;
+    float restitution;
+    uint32_t materialFlags;
+    uint16_t materialIndex0;
+    uint16_t materialIndex1;
+    float staticFriction;
+    float dynamicFriction;
+};
+struct physx_PxContactSet_Pod {
+    uint32_t mCount;
+    char structgen_pad0[4];
+    physx_PxModifiableContact_Pod* mContacts;
+};
+struct physx_PxContactModifyCallback_Pod {
+    void* vtable_;
+};
+struct physx_PxContactModifyPair_Pod {
+    physx_PxRigidActor_Pod* actor[2];
+    physx_PxShape_Pod* shape[2];
+    physx_PxTransform_Pod transform[2];
+    physx_PxContactSet_Pod contacts;
+};
+struct physx_PxCCDContactModifyCallback_Pod {
+    void* vtable_;
+};
+struct physx_PxDeletionListener_Pod {
+    void* vtable_;
+};
+struct physx_PxDataAccessFlags_Pod {
+    unsigned char mBits;
+};
+struct physx_PxLockedData_Pod {
+    void* vtable_;
+};
+struct physx_PxMaterialFlags_Pod {
+    uint16_t mBits;
+};
+struct physx_PxPhysics_Pod {
+    void* vtable_;
+};
+struct physx_PxSimulationEventCallback_Pod {
+    void* vtable_;
+};
+struct physx_PxBroadPhaseCallback_Pod {
+    void* vtable_;
+};
+struct physx_PxSceneLimits_Pod {
+    uint32_t maxNbActors;
+    uint32_t maxNbBodies;
+    uint32_t maxNbStaticShapes;
+    uint32_t maxNbDynamicShapes;
+    uint32_t maxNbAggregates;
+    uint32_t maxNbConstraints;
+    uint32_t maxNbRegions;
+    uint32_t maxNbBroadPhaseOverlaps;
+};
+struct physx_PxSceneFlags_Pod {
+    uint32_t mBits;
+};
+struct physx_PxCudaContextManager_Pod;
+struct physx_PxgDynamicsMemoryConfig_Pod {
+    uint32_t constraintBufferCapacity;
+    uint32_t contactBufferCapacity;
+    uint32_t tempBufferCapacity;
+    uint32_t contactStreamSize;
+    uint32_t patchStreamSize;
+    uint32_t forceStreamCapacity;
+    uint32_t heapCapacity;
+    uint32_t foundLostPairsCapacity;
+};
+struct physx_PxSceneDesc_Pod {
+    physx_PxVec3_Pod gravity;
+    char structgen_pad0[4];
+    physx_PxSimulationEventCallback_Pod* simulationEventCallback;
+    physx_PxContactModifyCallback_Pod* contactModifyCallback;
+    physx_PxCCDContactModifyCallback_Pod* ccdContactModifyCallback;
+    void* filterShaderData;
+    uint32_t filterShaderDataSize;
+    char structgen_pad1[4];
+    void* filterShader;
+    physx_PxSimulationFilterCallback_Pod* filterCallback;
+    unsigned int kineKineFilteringMode;
+    unsigned int staticKineFilteringMode;
+    unsigned int broadPhaseType;
+    char structgen_pad2[4];
+    physx_PxBroadPhaseCallback_Pod* broadPhaseCallback;
+    physx_PxSceneLimits_Pod limits;
+    unsigned int frictionType;
+    unsigned int solverType;
+    float bounceThresholdVelocity;
+    float frictionOffsetThreshold;
+    float ccdMaxSeparation;
+    float solverOffsetSlop;
+    physx_PxSceneFlags_Pod flags;
+    char structgen_pad3[4];
+    physx_PxCpuDispatcher_Pod* cpuDispatcher;
+    physx_PxCudaContextManager_Pod* cudaContextManager;
+    unsigned int staticStructure;
+    unsigned int dynamicStructure;
+    uint32_t dynamicTreeRebuildRateHint;
+    unsigned int sceneQueryUpdateMode;
+    void* userData;
+    uint32_t solverBatchSize;
+    uint32_t solverArticulationBatchSize;
+    uint32_t nbContactDataBlocks;
+    uint32_t maxNbContactDataBlocks;
+    float maxBiasCoefficient;
+    uint32_t contactReportStreamBufferSize;
+    uint32_t ccdMaxPasses;
+    float ccdThreshold;
+    float wakeCounterResetValue;
+    physx_PxBounds3_Pod sanityBounds;
+    physx_PxgDynamicsMemoryConfig_Pod gpuDynamicsConfig;
+    uint32_t gpuMaxNumPartitions;
+    uint32_t gpuComputeVersion;
+    char structgen_pad4[12];
+};
+struct physx_PxRigidStatic_Pod {
+    char structgen_pad0[8];
+    uint16_t mConcreteType;
+    physx_PxBaseFlags_Pod mBaseFlags;
+    char structgen_pad1[4];
+    void* userData;
+};
+struct physx_PxRigidDynamic_Pod {
+    char structgen_pad0[8];
+    uint16_t mConcreteType;
+    physx_PxBaseFlags_Pod mBaseFlags;
+    char structgen_pad1[4];
+    void* userData;
+};
+struct physx_PxPruningStructure_Pod {
+    char structgen_pad0[8];
+    uint16_t mConcreteType;
+    physx_PxBaseFlags_Pod mBaseFlags;
+    char structgen_pad1[4];
+};
+struct physx_PxDeletionEventFlags_Pod {
+    unsigned char mBits;
+};
+struct physx_PxPvd_Pod {
+    void* vtable_;
+};
+struct physx_PxRigidDynamicLockFlags_Pod {
+    uint16_t mBits;
+};
+struct physx_PxSimulationStatistics_Pod {
+    uint32_t nbActiveConstraints;
+    uint32_t nbActiveDynamicBodies;
+    uint32_t nbActiveKinematicBodies;
+    uint32_t nbStaticBodies;
+    uint32_t nbDynamicBodies;
+    uint32_t nbKinematicBodies;
+    uint32_t nbShapes[7];
+    uint32_t nbAggregates;
+    uint32_t nbArticulations;
+    uint32_t nbAxisSolverConstraints;
+    uint32_t compressedContactSize;
+    uint32_t requiredContactConstraintMemory;
+    uint32_t peakConstraintMemory;
+    uint32_t nbDiscreteContactPairsTotal;
+    uint32_t nbDiscreteContactPairsWithCacheHits;
+    uint32_t nbDiscreteContactPairsWithContacts;
+    uint32_t nbNewPairs;
+    uint32_t nbLostPairs;
+    uint32_t nbNewTouches;
+    uint32_t nbLostTouches;
+    uint32_t nbPartitions;
+    uint32_t nbBroadPhaseAdds;
+    uint32_t nbBroadPhaseRemoves;
+    uint32_t nbDiscreteContactPairs[7][7];
+    uint32_t nbCCDPairs[7][7];
+    uint32_t nbModifiedContactPairs[7][7];
+    uint32_t nbTriggerPairs[7][7];
+};
+struct physx_PxPvdSceneClient_Pod {
+    void* vtable_;
+};
+struct physx_PxPvdSceneFlags_Pod {
+    unsigned char mBits;
+};
+struct physx_pvdsdk_PvdDebugPoint_Pod;
+struct physx_pvdsdk_PvdDebugLine_Pod;
+struct physx_pvdsdk_PvdDebugTriangle_Pod;
+struct physx_pvdsdk_PvdDebugText_Pod;
+struct physx_pvdsdk_PvdClient_Pod;
+struct physx_PxDominanceGroupPair_Pod {
+    unsigned char dominance0;
+    unsigned char dominance1;
+};
+struct physx_PxActorTypeFlags_Pod {
+    uint16_t mBits;
+};
+struct physx_PxContactPairHeaderFlags_Pod {
+    uint16_t mBits;
+};
+struct physx_PxContactPairFlags_Pod {
+    uint16_t mBits;
+};
+struct physx_PxContactPair_Pod {
+    physx_PxShape_Pod* shapes[2];
+    unsigned char* contactPatches;
+    unsigned char* contactPoints;
+    float* contactImpulses;
+    uint32_t requiredBufferSize;
+    unsigned char contactCount;
+    unsigned char patchCount;
+    uint16_t contactStreamSize;
+    physx_PxContactPairFlags_Pod flags;
+    physx_PxPairFlags_Pod events;
+    uint32_t internalData[2];
+    char structgen_pad0[4];
+};
+struct physx_PxContactPairHeader_Pod {
+    physx_PxRigidActor_Pod* actors[2];
+    unsigned char* extraDataStream;
+    uint16_t extraDataStreamSize;
+    physx_PxContactPairHeaderFlags_Pod flags;
+    char structgen_pad0[4];
+    physx_PxContactPair_Pod* pairs;
+    uint32_t nbPairs;
+    char structgen_pad1[4];
+};
+struct physx_PxRaycastCallback_Pod {
+    void* vtable_;
+    physx_PxRaycastHit_Pod block;
+    bool hasBlock;
+    physx_PxRaycastHit_Pod* touches;
+    uint32_t maxNbTouches;
+    uint32_t nbTouches;
+};
+struct physx_PxSweepCallback_Pod {
+    void* vtable_;
+    physx_PxSweepHit_Pod block;
+    bool hasBlock;
+    physx_PxSweepHit_Pod* touches;
+    uint32_t maxNbTouches;
+    uint32_t nbTouches;
+};
+struct physx_PxOverlapCallback_Pod {
+    void* vtable_;
+    physx_PxOverlapHit_Pod block;
+    bool hasBlock;
+    physx_PxOverlapHit_Pod* touches;
+    uint32_t maxNbTouches;
+    uint32_t nbTouches;
+};
+struct physx_PxBroadPhaseCaps_Pod {
+    uint32_t maxNbRegions;
+    uint32_t maxNbObjects;
+    bool needsPredefinedBounds;
+    char structgen_pad0[3];
+};
+struct physx_PxBroadPhaseRegion_Pod {
+    physx_PxBounds3_Pod bounds;
+    void* userData;
+};
+struct physx_PxBroadPhaseRegionInfo_Pod {
+    physx_PxBroadPhaseRegion_Pod region;
+    uint32_t nbStaticObjects;
+    uint32_t nbDynamicObjects;
+    bool active;
+    bool overlap;
+    char structgen_pad0[6];
+};
+struct physx_PxSceneReadLock_Pod {
+    char structgen_pad0[8];
+};
+struct physx_PxSceneWriteLock_Pod {
+    char structgen_pad0[8];
+};
+struct physx_PxContactPairExtraDataItem_Pod {
+    unsigned char type;
+};
+struct physx_PxContactPairVelocity_Pod {
+    unsigned char type;
+    char structgen_pad0[3];
+    physx_PxVec3_Pod linearVelocity[2];
+    physx_PxVec3_Pod angularVelocity[2];
+};
+struct physx_PxContactPairPose_Pod {
+    unsigned char type;
+    char structgen_pad0[3];
+    physx_PxTransform_Pod globalPose[2];
+};
+struct physx_PxContactPairIndex_Pod {
+    unsigned char type;
+    char structgen_pad0[1];
+    uint16_t index;
+};
+struct physx_PxContactPairExtraDataIterator_Pod {
+    unsigned char* currPtr;
+    unsigned char* endPtr;
+    physx_PxContactPairVelocity_Pod* preSolverVelocity;
+    physx_PxContactPairVelocity_Pod* postSolverVelocity;
+    physx_PxContactPairPose_Pod* eventPose;
+    uint32_t contactPairIndex;
+    char structgen_pad0[4];
+};
+struct physx_PxContactPairPoint_Pod {
+    physx_PxVec3_Pod position;
+    float separation;
+    physx_PxVec3_Pod normal;
+    uint32_t internalFaceIndex0;
+    physx_PxVec3_Pod impulse;
+    uint32_t internalFaceIndex1;
+};
+struct physx_PxTriggerPairFlags_Pod {
+    unsigned char mBits;
+};
+struct physx_PxTriggerPair_Pod {
+    physx_PxShape_Pod* triggerShape;
+    physx_PxRigidActor_Pod* triggerActor;
+    physx_PxShape_Pod* otherShape;
+    physx_PxRigidActor_Pod* otherActor;
+    unsigned int status;
+    physx_PxTriggerPairFlags_Pod flags;
+    char structgen_pad0[3];
+};
+struct physx_PxConstraintInfo_Pod {
+    physx_PxConstraint_Pod* constraint;
+    void* externalReference;
+    uint32_t type;
+    char structgen_pad0[4];
+};
+struct physx_PxExtendedVec3_Pod {
+    double x;
+    double y;
+    double z;
+};
+struct physx_PxObstacle_Pod {
+    int mType;
+    char structgen_pad0[4];
+    void* mUserData;
+    physx_PxExtendedVec3_Pod mPos;
+    physx_PxQuat_Pod mRot;
+};
+struct physx_PxBoxObstacle_Pod {
+    int mType;
+    char structgen_pad0[4];
+    void* mUserData;
+    physx_PxExtendedVec3_Pod mPos;
+    physx_PxQuat_Pod mRot;
+    physx_PxVec3_Pod mHalfExtents;
+    char structgen_pad1[4];
+};
+struct physx_PxCapsuleObstacle_Pod {
+    int mType;
+    char structgen_pad0[4];
+    void* mUserData;
+    physx_PxExtendedVec3_Pod mPos;
+    physx_PxQuat_Pod mRot;
+    float mHalfHeight;
+    float mRadius;
+};
+struct physx_PxObstacleContext_Pod {
+    void* vtable_;
+};
+struct physx_PxControllerManager_Pod {
+    void* vtable_;
+};
+struct physx_PxUserControllerHitReport_Pod {
+    void* vtable_;
+};
+struct physx_PxController_Pod {
+    void* vtable_;
+};
+struct physx_PxControllerShapeHit_Pod {
+    physx_PxController_Pod* controller;
+    physx_PxExtendedVec3_Pod worldPos;
+    physx_PxVec3_Pod worldNormal;
+    physx_PxVec3_Pod dir;
+    float length;
+    char structgen_pad0[4];
+    physx_PxShape_Pod* shape;
+    physx_PxRigidActor_Pod* actor;
+    uint32_t triangleIndex;
+    char structgen_pad1[4];
+};
+struct physx_PxControllersHit_Pod {
+    physx_PxController_Pod* controller;
+    physx_PxExtendedVec3_Pod worldPos;
+    physx_PxVec3_Pod worldNormal;
+    physx_PxVec3_Pod dir;
+    float length;
+    char structgen_pad0[4];
+    physx_PxController_Pod* other;
+};
+struct physx_PxControllerObstacleHit_Pod {
+    physx_PxController_Pod* controller;
+    physx_PxExtendedVec3_Pod worldPos;
+    physx_PxVec3_Pod worldNormal;
+    physx_PxVec3_Pod dir;
+    float length;
+    char structgen_pad0[4];
+    void* userData;
+};
+struct physx_PxControllerFilterCallback_Pod {
+    void* vtable_;
+};
+struct physx_PxControllerFilters_Pod {
+    physx_PxFilterData_Pod* mFilterData;
+    physx_PxQueryFilterCallback_Pod* mFilterCallback;
+    physx_PxQueryFlags_Pod mFilterFlags;
+    char structgen_pad0[6];
+    physx_PxControllerFilterCallback_Pod* mCCTFilterCallback;
+};
+struct physx_PxControllerBehaviorCallback_Pod {
+    void* vtable_;
+};
+struct physx_PxControllerDesc_Pod {
+    char structgen_pad0[8];
+    physx_PxExtendedVec3_Pod position;
+    physx_PxVec3_Pod upDirection;
+    float slopeLimit;
+    float invisibleWallHeight;
+    float maxJumpHeight;
+    float contactOffset;
+    float stepOffset;
+    float density;
+    float scaleCoeff;
+    float volumeGrowth;
+    char structgen_pad1[4];
+    physx_PxUserControllerHitReport_Pod* reportCallback;
+    physx_PxControllerBehaviorCallback_Pod* behaviorCallback;
+    unsigned int nonWalkableMode;
+    char structgen_pad2[4];
+    physx_PxMaterial_Pod* material;
+    bool registerDeletionListener;
+    char structgen_pad3[7];
+    void* userData;
+    unsigned int mType;
+    char structgen_pad4[4];
+};
+struct physx_PxControllerCollisionFlags_Pod {
+    unsigned char mBits;
+};
+struct physx_PxControllerState_Pod {
+    physx_PxVec3_Pod deltaXP;
+    char structgen_pad0[4];
+    physx_PxShape_Pod* touchedShape;
+    physx_PxRigidActor_Pod* touchedActor;
+    uint32_t touchedObstacleHandle;
+    uint32_t collisionFlags;
+    bool standOnAnotherCCT;
+    bool standOnObstacle;
+    bool isMovingUp;
+    char structgen_pad1[5];
+};
+struct physx_PxControllerStats_Pod {
+    uint16_t nbIterations;
+    uint16_t nbFullUpdates;
+    uint16_t nbPartialUpdates;
+    uint16_t nbTessellation;
+};
+struct physx_PxBoxControllerDesc_Pod {
+    char structgen_pad0[8];
+    physx_PxExtendedVec3_Pod position;
+    physx_PxVec3_Pod upDirection;
+    float slopeLimit;
+    float invisibleWallHeight;
+    float maxJumpHeight;
+    float contactOffset;
+    float stepOffset;
+    float density;
+    float scaleCoeff;
+    float volumeGrowth;
+    char structgen_pad1[4];
+    physx_PxUserControllerHitReport_Pod* reportCallback;
+    physx_PxControllerBehaviorCallback_Pod* behaviorCallback;
+    unsigned int nonWalkableMode;
+    char structgen_pad2[4];
+    physx_PxMaterial_Pod* material;
+    bool registerDeletionListener;
+    char structgen_pad3[7];
+    void* userData;
+    unsigned int mType;
+    float halfHeight;
+    float halfSideExtent;
+    float halfForwardExtent;
+};
+struct physx_PxBoxController_Pod {
+    void* vtable_;
+};
+struct physx_PxCapsuleControllerDesc_Pod {
+    char structgen_pad0[8];
+    physx_PxExtendedVec3_Pod position;
+    physx_PxVec3_Pod upDirection;
+    float slopeLimit;
+    float invisibleWallHeight;
+    float maxJumpHeight;
+    float contactOffset;
+    float stepOffset;
+    float density;
+    float scaleCoeff;
+    float volumeGrowth;
+    char structgen_pad1[4];
+    physx_PxUserControllerHitReport_Pod* reportCallback;
+    physx_PxControllerBehaviorCallback_Pod* behaviorCallback;
+    unsigned int nonWalkableMode;
+    char structgen_pad2[4];
+    physx_PxMaterial_Pod* material;
+    bool registerDeletionListener;
+    char structgen_pad3[7];
+    void* userData;
+    unsigned int mType;
+    float radius;
+    float height;
+    unsigned int climbingMode;
+};
+struct physx_PxCapsuleController_Pod {
+    void* vtable_;
+};
+struct physx_PxControllerBehaviorFlags_Pod {
+    unsigned char mBits;
+};
+struct physx_PxControllerDebugRenderFlags_Pod {
+    uint32_t mBits;
+};
+struct physx_PxConvexFlags_Pod {
+    uint16_t mBits;
+};
+struct physx_PxConvexMeshDesc_Pod {
+    physx_PxBoundedData_Pod points;
+    physx_PxBoundedData_Pod polygons;
+    physx_PxBoundedData_Pod indices;
+    physx_PxConvexFlags_Pod flags;
+    uint16_t vertexLimit;
+    uint16_t quantizedCount;
+    char structgen_pad0[2];
+};
+struct PxTypedStridedData_physx_PxMaterialTableIndex__Pod {
+    uint32_t stride;
+    uint16_t* data;
+};
+struct physx_PxTriangleMeshDesc_Pod {
+    physx_PxBoundedData_Pod points;
+    physx_PxBoundedData_Pod triangles;
+    physx_PxMeshFlags_Pod flags;
+    char structgen_pad0[6];
+    PxTypedStridedData_physx_PxMaterialTableIndex__Pod materialIndices;
+};
+struct physx_PxBVH33MidphaseDesc_Pod {
+    float meshSizePerformanceTradeOff;
+    unsigned int meshCookingHint;
+};
+struct physx_PxBVH34MidphaseDesc_Pod {
+    uint32_t numPrimsPerLeaf;
+};
+struct Anonymous216_Pod {
+    physx_PxBVH33MidphaseDesc_Pod mBVH33Desc;
+    physx_PxBVH34MidphaseDesc_Pod mBVH34Desc;
+};
+struct physx_PxMidphaseDesc_Pod {
+    char structgen_pad0[8];
+    unsigned int mType;
+};
+struct physx_PxBVHStructureDesc_Pod {
+    physx_PxBoundedData_Pod bounds;
+};
+struct physx_PxMeshPreprocessingFlags_Pod {
+    uint32_t mBits;
+};
+struct physx_PxCookingParams_Pod {
+    float areaTestEpsilon;
+    float planeTolerance;
+    unsigned int convexMeshCookingType;
+    bool suppressTriangleMeshRemapTable;
+    bool buildTriangleAdjacencies;
+    bool buildGPUData;
+    char structgen_pad0[1];
+    physx_PxTolerancesScale_Pod scale;
+    physx_PxMeshPreprocessingFlags_Pod meshPreprocessParams;
+    float meshWeldTolerance;
+    physx_PxMidphaseDesc_Pod midphaseDesc;
+    uint32_t gaussMapLimit;
+};
+struct physx_PxCooking_Pod {
+    void* vtable_;
+};
+struct physx_PxDefaultMemoryOutputStream_Pod {
+    char structgen_pad0[32];
+};
+struct physx_PxDefaultMemoryInputData_Pod {
+    char structgen_pad0[32];
+};
+struct physx_PxDefaultFileOutputStream_Pod {
+    char structgen_pad0[16];
+};
+struct physx_PxDefaultFileInputData_Pod {
+    char structgen_pad0[24];
+};
+struct physx_PxSpring_Pod {
+    float stiffness;
+    float damping;
+};
+struct physx_PxDistanceJoint_Pod {
+    char structgen_pad0[8];
+    uint16_t mConcreteType;
+    physx_PxBaseFlags_Pod mBaseFlags;
+    char structgen_pad1[4];
+    void* userData;
+};
+struct physx_PxDistanceJointFlags_Pod {
+    uint16_t mBits;
+};
+struct physx_PxDefaultAllocator_Pod {
+    void* vtable_;
+};
+struct physx_PxContactJoint_Pod {
+    char structgen_pad0[8];
+    uint16_t mConcreteType;
+    physx_PxBaseFlags_Pod mBaseFlags;
+    char structgen_pad1[4];
+    void* userData;
+};
+struct physx_PxJacobianRow_Pod {
+    physx_PxVec3_Pod linear0;
+    physx_PxVec3_Pod linear1;
+    physx_PxVec3_Pod angular0;
+    physx_PxVec3_Pod angular1;
+};
+struct physx_PxFixedJoint_Pod {
+    char structgen_pad0[8];
+    uint16_t mConcreteType;
+    physx_PxBaseFlags_Pod mBaseFlags;
+    char structgen_pad1[4];
+    void* userData;
+};
+struct physx_PxJointLimitParameters_Pod {
+    float restitution;
+    float bounceThreshold;
+    float stiffness;
+    float damping;
+    float contactDistance;
+};
+struct physx_PxJointLinearLimit_Pod {
+    float restitution;
+    float bounceThreshold;
+    float stiffness;
+    float damping;
+    float contactDistance;
+    float value;
+};
+struct physx_PxJointLinearLimitPair_Pod {
+    float restitution;
+    float bounceThreshold;
+    float stiffness;
+    float damping;
+    float contactDistance;
+    float upper;
+    float lower;
+};
+struct physx_PxJointAngularLimitPair_Pod {
+    float restitution;
+    float bounceThreshold;
+    float stiffness;
+    float damping;
+    float contactDistance;
+    float upper;
+    float lower;
+};
+struct physx_PxJointLimitCone_Pod {
+    float restitution;
+    float bounceThreshold;
+    float stiffness;
+    float damping;
+    float contactDistance;
+    float yAngle;
+    float zAngle;
+};
+struct physx_PxJointLimitPyramid_Pod {
+    float restitution;
+    float bounceThreshold;
+    float stiffness;
+    float damping;
+    float contactDistance;
+    float yAngleMin;
+    float yAngleMax;
+    float zAngleMin;
+    float zAngleMax;
+};
+struct physx_PxPrismaticJoint_Pod {
+    char structgen_pad0[8];
+    uint16_t mConcreteType;
+    physx_PxBaseFlags_Pod mBaseFlags;
+    char structgen_pad1[4];
+    void* userData;
+};
+struct physx_PxPrismaticJointFlags_Pod {
+    uint16_t mBits;
+};
+struct physx_PxRevoluteJoint_Pod {
+    char structgen_pad0[8];
+    uint16_t mConcreteType;
+    physx_PxBaseFlags_Pod mBaseFlags;
+    char structgen_pad1[4];
+    void* userData;
+};
+struct physx_PxRevoluteJointFlags_Pod {
+    uint16_t mBits;
+};
+struct physx_PxSphericalJoint_Pod {
+    char structgen_pad0[8];
+    uint16_t mConcreteType;
+    physx_PxBaseFlags_Pod mBaseFlags;
+    char structgen_pad1[4];
+    void* userData;
+};
+struct physx_PxSphericalJointFlags_Pod {
+    uint16_t mBits;
+};
+struct physx_PxD6Joint_Pod {
+    char structgen_pad0[8];
+    uint16_t mConcreteType;
+    physx_PxBaseFlags_Pod mBaseFlags;
+    char structgen_pad1[4];
+    void* userData;
+};
+struct physx_PxD6JointDriveFlags_Pod {
+    uint32_t mBits;
+};
+struct physx_PxD6JointDrive_Pod {
+    float stiffness;
+    float damping;
+    float forceLimit;
+    physx_PxD6JointDriveFlags_Pod flags;
+};
+struct physx_PxGroupsMask_Pod {
+    uint16_t bits0;
+    uint16_t bits1;
+    uint16_t bits2;
+    uint16_t bits3;
+};
+struct physx_PxDefaultErrorCallback_Pod {
+    void* vtable_;
+};
+struct physx_PxMassProperties_Pod {
+    physx_PxMat33_Pod inertiaTensor;
+    physx_PxVec3_Pod centerOfMass;
+    float mass;
+};
+struct physx_PxMeshOverlapUtil_Pod {
+    char structgen_pad0[1040];
+};
+struct physx_PxSerialization_PxXmlMiscParameter_Pod {
+    physx_PxVec3_Pod upVector;
+    physx_PxTolerancesScale_Pod scale;
+};
+struct physx_PxBinaryConverter_Pod {
+    void* vtable_;
+};
+struct physx_PxDefaultCpuDispatcher_Pod {
+    void* vtable_;
+};
+struct physx_PxSceneQueryHit_Pod {
+    physx_PxRigidActor_Pod* actor;
+    physx_PxShape_Pod* shape;
+    uint32_t faceIndex;
+    char structgen_pad0[4];
+};
+struct physx_PxSceneQueryFilterData_Pod {
+    physx_PxFilterData_Pod data;
+    physx_PxQueryFlags_Pod flags;
+    char structgen_pad0[2];
+};
+struct physx_PxSceneQueryFilterCallback_Pod {
+    void* vtable_;
+};
+struct physx_PxSceneQueryCache_Pod {
+    physx_PxShape_Pod* shape;
+    physx_PxRigidActor_Pod* actor;
+    uint32_t faceIndex;
+    char structgen_pad0[4];
+};
+struct physx_PxSceneQueryFlags_Pod {
+    uint16_t mBits;
+};
+struct physx_PxRepXObject_Pod {
+    char* typeName;
+    void* serializable;
+    uint64_t id;
+};
+struct physx_PxRepXInstantiationArgs_Pod {
+    char structgen_pad0[8];
+    physx_PxCooking_Pod* cooker;
+    physx_PxStringTable_Pod* stringTable;
+};
+struct physx_XmlWriter_Pod;
+struct physx_MemoryBuffer_Pod;
+struct physx_XmlReader_Pod;
+struct physx_XmlMemoryAllocator_Pod;
+struct physx_PxVehicleChassisData_Pod {
+    physx_PxVec3_Pod mMOI;
+    float mMass;
+    physx_PxVec3_Pod mCMOffset;
+    char structgen_pad0[4];
+};
+struct PxFixedSizeLookupTable_eMAX_NB_ENGINE_TORQUE_CURVE_ENTRIES__Pod {
+    float mDataPairs[16];
+    uint32_t mNbDataPairs;
+    uint32_t mPad[3];
+};
+struct physx_PxVehicleEngineData_Pod {
+    PxFixedSizeLookupTable_eMAX_NB_ENGINE_TORQUE_CURVE_ENTRIES__Pod mTorqueCurve;
+    float mMOI;
+    float mPeakTorque;
+    float mMaxOmega;
+    float mDampingRateFullThrottle;
+    float mDampingRateZeroThrottleClutchEngaged;
+    float mDampingRateZeroThrottleClutchDisengaged;
+    char structgen_pad0[8];
+};
+struct physx_PxVehicleGearsData_Pod {
+    float mRatios[32];
+    float mFinalRatio;
+    uint32_t mNbRatios;
+    float mSwitchTime;
+    char structgen_pad0[4];
+};
+struct physx_PxVehicleAutoBoxData_Pod {
+    float mUpRatios[32];
+    float mDownRatios[32];
+};
+struct physx_PxVehicleDifferential4WData_Pod {
+    float mFrontRearSplit;
+    float mFrontLeftRightSplit;
+    float mRearLeftRightSplit;
+    float mCentreBias;
+    float mFrontBias;
+    float mRearBias;
+    unsigned int mType;
+    char structgen_pad0[4];
+};
+struct physx_PxVehicleDifferentialNWData_Pod {
+    char structgen_pad0[16];
+};
+struct physx_PxVehicleAckermannGeometryData_Pod {
+    float mAccuracy;
+    float mFrontWidth;
+    float mRearWidth;
+    float mAxleSeparation;
+};
+struct physx_PxVehicleClutchData_Pod {
+    float mStrength;
+    unsigned int mAccuracyMode;
+    uint32_t mEstimateIterations;
+    char structgen_pad0[4];
+};
+struct physx_PxVehicleTireLoadFilterData_Pod {
+    float mMinNormalisedLoad;
+    float mMinFilteredNormalisedLoad;
+    float mMaxNormalisedLoad;
+    float mMaxFilteredNormalisedLoad;
+    char structgen_pad0[16];
+};
+struct physx_PxVehicleWheelData_Pod {
+    float mRadius;
+    float mWidth;
+    float mMass;
+    float mMOI;
+    float mDampingRate;
+    float mMaxBrakeTorque;
+    float mMaxHandBrakeTorque;
+    float mMaxSteer;
+    float mToeAngle;
+    char structgen_pad0[12];
+};
+struct physx_PxVehicleSuspensionData_Pod {
+    float mSpringStrength;
+    float mSpringDamperRate;
+    float mMaxCompression;
+    float mMaxDroop;
+    float mSprungMass;
+    float mCamberAtRest;
+    float mCamberAtMaxCompression;
+    float mCamberAtMaxDroop;
+    char structgen_pad0[16];
+};
+struct physx_PxVehicleAntiRollBarData_Pod {
+    uint32_t mWheel0;
+    uint32_t mWheel1;
+    float mStiffness;
+    char structgen_pad0[4];
+};
+struct physx_PxVehicleTireData_Pod {
+    float mLatStiffX;
+    float mLatStiffY;
+    float mLongitudinalStiffnessPerUnitGravity;
+    float mCamberStiffnessPerUnitGravity;
+    float mFrictionVsSlipGraph[3][2];
+    uint32_t mType;
+    char structgen_pad0[20];
+};
+struct physx_PxVehicleWheels4SimData_Pod;
+struct physx_PxVehicleWheelsSimData_Pod {
+    char structgen_pad0[96];
+};
+struct physx_PxVehicleWheels4DynData_Pod;
+struct physx_PxVehicleTireForceCalculator_Pod;
+struct physx_PxVehicleWheelsDynData_Pod {
+    char structgen_pad0[48];
+};
+struct physx_PxVehicleWheels_Pod {
+    char structgen_pad0[8];
+    uint16_t mConcreteType;
+    physx_PxBaseFlags_Pod mBaseFlags;
+    char structgen_pad1[4];
+    physx_PxVehicleWheelsSimData_Pod mWheelsSimData;
+    physx_PxVehicleWheelsDynData_Pod mWheelsDynData;
+    physx_PxRigidDynamic_Pod* mActor;
+    char structgen_pad2[5];
+    unsigned char mType;
+    unsigned char mPad0[14];
+    char structgen_pad3[4];
+};
+struct physx_PxVehicleDriveSimData_Pod {
+    physx_PxVehicleEngineData_Pod mEngine;
+    physx_PxVehicleGearsData_Pod mGears;
+    physx_PxVehicleClutchData_Pod mClutch;
+    physx_PxVehicleAutoBoxData_Pod mAutoBox;
+};
+struct physx_PxVehicleDriveDynData_Pod {
+    float mControlAnalogVals[16];
+    bool mUseAutoGears;
+    bool mGearUpPressed;
+    bool mGearDownPressed;
+    char structgen_pad0[1];
+    uint32_t mCurrentGear;
+    uint32_t mTargetGear;
+    float mEnginespeed;
+    float mGearSwitchTime;
+    float mAutoBoxSwitchTime;
+    char structgen_pad1[8];
+};
+struct physx_PxVehicleDrive_Pod {
+    char structgen_pad0[8];
+    uint16_t mConcreteType;
+    physx_PxBaseFlags_Pod mBaseFlags;
+    char structgen_pad1[4];
+    physx_PxVehicleWheelsSimData_Pod mWheelsSimData;
+    physx_PxVehicleWheelsDynData_Pod mWheelsDynData;
+    physx_PxRigidDynamic_Pod* mActor;
+    char structgen_pad2[5];
+    unsigned char mType;
+    unsigned char mPad0[14];
+    physx_PxVehicleDriveDynData_Pod mDriveDynData;
+    char structgen_pad3[4];
+};
+struct physx_PxVehicleDriveSimData4W_Pod {
+    physx_PxVehicleEngineData_Pod mEngine;
+    physx_PxVehicleGearsData_Pod mGears;
+    physx_PxVehicleClutchData_Pod mClutch;
+    physx_PxVehicleAutoBoxData_Pod mAutoBox;
+    char structgen_pad0[48];
+};
+struct physx_PxVehicleDrive4W_Pod {
+    char structgen_pad0[8];
+    uint16_t mConcreteType;
+    physx_PxBaseFlags_Pod mBaseFlags;
+    char structgen_pad1[4];
+    physx_PxVehicleWheelsSimData_Pod mWheelsSimData;
+    physx_PxVehicleWheelsDynData_Pod mWheelsDynData;
+    physx_PxRigidDynamic_Pod* mActor;
+    char structgen_pad2[5];
+    unsigned char mType;
+    unsigned char mPad0[14];
+    physx_PxVehicleDriveDynData_Pod mDriveDynData;
+    physx_PxVehicleDriveSimData4W_Pod mDriveSimData;
+    char structgen_pad3[4];
+};
+struct physx_PxVehicleDriveTank_Pod {
+    char structgen_pad0[8];
+    uint16_t mConcreteType;
+    physx_PxBaseFlags_Pod mBaseFlags;
+    char structgen_pad1[4];
+    physx_PxVehicleWheelsSimData_Pod mWheelsSimData;
+    physx_PxVehicleWheelsDynData_Pod mWheelsDynData;
+    physx_PxRigidDynamic_Pod* mActor;
+    char structgen_pad2[5];
+    unsigned char mType;
+    unsigned char mPad0[14];
+    physx_PxVehicleDriveDynData_Pod mDriveDynData;
+    physx_PxVehicleDriveSimData_Pod mDriveSimData;
+    char structgen_pad3[20];
+};
+struct physx_PxVehicleDrivableSurfaceType_Pod {
+    uint32_t mType;
+};
+struct physx_PxVehicleDrivableSurfaceToTireFrictionPairs_Pod {
+    char structgen_pad0[48];
+};
+struct physx_PxWheelQueryResult_Pod {
+    physx_PxVec3_Pod suspLineStart;
+    physx_PxVec3_Pod suspLineDir;
+    float suspLineLength;
+    bool isInAir;
+    char structgen_pad0[3];
+    physx_PxActor_Pod* tireContactActor;
+    physx_PxShape_Pod* tireContactShape;
+    physx_PxMaterial_Pod* tireSurfaceMaterial;
+    uint32_t tireSurfaceType;
+    physx_PxVec3_Pod tireContactPoint;
+    physx_PxVec3_Pod tireContactNormal;
+    float tireFriction;
+    float suspJounce;
+    float suspSpringForce;
+    physx_PxVec3_Pod tireLongitudinalDir;
+    physx_PxVec3_Pod tireLateralDir;
+    float longitudinalSlip;
+    float lateralSlip;
+    float steerAngle;
+    physx_PxTransform_Pod localPose;
+};
+struct physx_PxVehicleWheelConcurrentUpdateData_Pod {
+    char structgen_pad0[64];
+};
+struct physx_PxVehicleConcurrentUpdateData_Pod {
+    physx_PxVehicleWheelConcurrentUpdateData_Pod* concurrentWheelUpdates;
+    uint32_t nbConcurrentWheelUpdates;
+    char structgen_pad0[28];
+};
+struct physx_PxVehicleWheelQueryResult_Pod {
+    physx_PxWheelQueryResult_Pod* wheelQueryResults;
+    uint32_t nbWheelQueryResults;
+    char structgen_pad0[4];
+};
+struct physx_PxVehicleGraph_Pod {
+    char structgen_pad0[15840];
+};
+struct physx_PxVehicleTelemetryData_Pod {
+    char structgen_pad0[48];
+};
+struct physx_PxVehicleDriveSimDataNW_Pod {
+    physx_PxVehicleEngineData_Pod mEngine;
+    physx_PxVehicleGearsData_Pod mGears;
+    physx_PxVehicleClutchData_Pod mClutch;
+    physx_PxVehicleAutoBoxData_Pod mAutoBox;
+    char structgen_pad0[16];
+};
+struct physx_PxVehicleDriveNW_Pod {
+    char structgen_pad0[8];
+    uint16_t mConcreteType;
+    physx_PxBaseFlags_Pod mBaseFlags;
+    char structgen_pad1[4];
+    physx_PxVehicleWheelsSimData_Pod mWheelsSimData;
+    physx_PxVehicleWheelsDynData_Pod mWheelsDynData;
+    physx_PxRigidDynamic_Pod* mActor;
+    char structgen_pad2[5];
+    unsigned char mType;
+    unsigned char mPad0[14];
+    physx_PxVehicleDriveDynData_Pod mDriveDynData;
+    physx_PxVehicleDriveSimDataNW_Pod mDriveSimData;
+    char structgen_pad3[4];
+};
+struct physx_PxVehicleDrive4WRawInputData_Pod {
+    char structgen_pad0[40];
+};
+struct physx_PxVehicleKeySmoothingData_Pod {
+    float mRiseRates[16];
+    float mFallRates[16];
+};
+struct PxFixedSizeLookupTable_8__Pod {
+    float mDataPairs[16];
+    uint32_t mNbDataPairs;
+    uint32_t mPad[3];
+};
+struct physx_PxVehiclePadSmoothingData_Pod {
+    float mRiseRates[16];
+    float mFallRates[16];
+};
+struct physx_PxVehicleDriveNWRawInputData_Pod {
+    char structgen_pad0[40];
+};
+struct physx_PxVehicleDriveTankRawInputData_Pod {
+    char structgen_pad0[32];
+};
+struct physx_PxVehicleCopyDynamicsMap_Pod {
+    unsigned char sourceWheelIds[20];
+    unsigned char targetWheelIds[20];
+};
+struct physx_PxVehicleGraphChannelDesc_Pod {
+    float mMinY;
+    float mMaxY;
+    float mMidY;
+    physx_PxVec3_Pod mColorLow;
+    physx_PxVec3_Pod mColorHigh;
+    char structgen_pad0[4];
+    char* mTitle;
+};
+struct physx_PxVehicleGraphDesc_Pod {
+    char structgen_pad0[32];
+};
+struct physx_PxVehicleNoDrive_Pod {
+    char structgen_pad0[8];
+    uint16_t mConcreteType;
+    physx_PxBaseFlags_Pod mBaseFlags;
+    char structgen_pad1[4];
+    physx_PxVehicleWheelsSimData_Pod mWheelsSimData;
+    physx_PxVehicleWheelsDynData_Pod mWheelsDynData;
+    physx_PxRigidDynamic_Pod* mActor;
+    char structgen_pad2[5];
+    unsigned char mType;
+    unsigned char mPad0[14];
+    char structgen_pad3[36];
+};
+struct physx_PxProfileScoped_Pod {
+    physx_PxProfilerCallback_Pod* mCallback;
+    char* mEventName;
+    void* mProfilerData;
+    uint64_t mContextId;
+    bool mDetached;
+    char structgen_pad0[7];
+};
+struct physx_PxPvdTransport_Pod {
+    void* vtable_;
+};
+struct physx_PxPvdInstrumentationFlags_Pod {
+    unsigned char mBits;
+};

--- a/physx-sys/src/lib.rs
+++ b/physx-sys/src/lib.rs
@@ -154,6 +154,13 @@ include!("generated/x86_64-apple-darwin/structgen.rs");
 
 #[cfg(all(
     not(feature = "structgen"),
+    target_os = "macos",
+    target_arch = "aarch64",
+))]
+include!("generated/aarch64-apple-darwin/structgen.rs");
+
+#[cfg(all(
+    not(feature = "structgen"),
     target_os = "windows",
     target_arch = "x86_64",
     target_env = "msvc",


### PR DESCRIPTION
Adds initial support for Mac M1 ARM CPUs.

This may not be correct as had problems running our pxbind structgen utility on Mac M1 so for now just copy'n'pasted the x86_64 Mac structgen files. Does seem to run but could be subtle differences (that could cause catastrophic failures)?

Resolves: #92