### PR TITLE
Make glam an optional dependency

### DIFF
--- a/physx/CHANGELOG.md
+++ b/physx/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## [Unreleased]
 
+- [PR#129](https://github.com/EmbarkStudios/physx-rs/pull/129) Glam is now an
+  optional dependency and has been updated. You can enable the `glam` feature
+  to continue to use `glam` with `physx-sys` types.
 - [Updated various struct names and trait implementations](https://github.com/EmbarkStudios/physx-rs/pull/130):
   - `BVHStructure` is now named `BvhStructure`.
   - `PxBVHStructureDesc` is now named `PxBvhStructureDesc`.

--- a/physx/Cargo.toml
+++ b/physx/Cargo.toml
@@ -18,7 +18,7 @@ physx-sys = { version = "0.4.10", path = "../physx-sys" }
 
 enumflags2 = "0.6"
 log = "0.4"
-glam = "0.12"
+glam = { version = "0.13", optional = true }
 thiserror = "1.0.20"
 
 [features]

--- a/physx/src/math/glam.rs
+++ b/physx/src/math/glam.rs
@@ -1,0 +1,55 @@
+use super::*;
+use ::glam::*;
+
+impl From<Vec3> for PxExtendedVec3 {
+    fn from(vec: Vec3) -> Self {
+        Self {
+            obj: physx_sys::PxExtendedVec3 {
+                x: vec.x as f64,
+                y: vec.y as f64,
+                z: vec.z as f64,
+            },
+        }
+    }
+}
+
+impl From<Quat> for PxQuat {
+    fn from(quat: Quat) -> Self {
+        let (x, y, z, w) = quat.into();
+        Self::new(x, y, z, w)
+    }
+}
+
+impl From<PxQuat> for Quat {
+    fn from(value: PxQuat) -> Self {
+        let physx_sys::PxQuat { x, y, z, w } = value.obj;
+        Quat::from_xyzw(x, y, z, w)
+    }
+}
+
+impl From<Mat4> for PxTransform {
+    fn from(mat: Mat4) -> Self {
+        let (_, rotation, translation) = mat.to_scale_rotation_translation();
+        Self::from_translation_rotation(&translation.into(), &rotation.into())
+    }
+}
+
+impl From<PxTransform> for Mat4 {
+    fn from(value: PxTransform) -> Self {
+        Self::from_rotation_translation(value.rotation().into(), value.translation().into())
+    }
+}
+
+impl From<Vec3> for PxVec3 {
+    fn from(v: Vec3) -> Self {
+        let (x, y, z) = v.into();
+        Self::new(x, y, z)
+    }
+}
+
+impl From<PxVec3> for Vec3 {
+    fn from(value: PxVec3) -> Self {
+        let physx_sys::PxVec3 { x, y, z } = value.obj;
+        Vec3::new(x, y, z)
+    }
+}

--- a/physx/src/math/mod.rs
+++ b/physx/src/math/mod.rs
@@ -14,6 +14,8 @@ mod quat;
 pub use quat::PxQuat;
 mod vec3;
 pub use vec3::PxVec3;
+#[cfg(feature = "glam")]
+mod glam;
 
 #[derive(Copy, Clone)]
 #[repr(transparent)]
@@ -30,18 +32,6 @@ impl From<(f64, f64, f64)> for PxExtendedVec3 {
                 x: vec.0,
                 y: vec.1,
                 z: vec.2,
-            },
-        }
-    }
-}
-
-impl From<glam::Vec3> for PxExtendedVec3 {
-    fn from(vec: glam::Vec3) -> Self {
-        Self {
-            obj: physx_sys::PxExtendedVec3 {
-                x: vec.x as f64,
-                y: vec.y as f64,
-                z: vec.z as f64,
             },
         }
     }

--- a/physx/src/math/quat.rs
+++ b/physx/src/math/quat.rs
@@ -1,7 +1,5 @@
 use crate::{math::PxVec3, traits::Class};
 
-use glam::Quat;
-
 use physx_sys::{
     PxQuat_dot, PxQuat_getAngle, PxQuat_getAngle_1, PxQuat_getBasisVector0, PxQuat_getBasisVector1,
     PxQuat_getBasisVector2, PxQuat_getConjugate, PxQuat_getImaginaryPart, PxQuat_getNormalized,
@@ -13,7 +11,7 @@ use physx_sys::{
 #[derive(Copy, Clone)]
 #[repr(transparent)]
 pub struct PxQuat {
-    obj: physx_sys::PxQuat,
+    pub(super) obj: physx_sys::PxQuat,
 }
 
 crate::DeriveClassForNewType!(PxQuat: PxQuat);
@@ -33,20 +31,6 @@ impl From<physx_sys::PxQuat> for PxQuat {
 impl From<PxQuat> for physx_sys::PxQuat {
     fn from(value: PxQuat) -> Self {
         value.obj
-    }
-}
-
-impl From<Quat> for PxQuat {
-    fn from(quat: Quat) -> Self {
-        let (x, y, z, w) = quat.into();
-        Self::new(x, y, z, w)
-    }
-}
-
-impl From<PxQuat> for Quat {
-    fn from(value: PxQuat) -> Self {
-        let physx_sys::PxQuat { x, y, z, w } = value.obj;
-        Quat::from_xyzw(x, y, z, w)
     }
 }
 

--- a/physx/src/math/transform.rs
+++ b/physx/src/math/transform.rs
@@ -3,8 +3,6 @@ use crate::{
     traits::Class,
 };
 
-use glam::Mat4;
-
 //pub use physx_sys::PxTransform;
 use physx_sys::{
     PxPlane, PxTransform_getInverse, PxTransform_getNormalized, PxTransform_inverseTransform,
@@ -41,19 +39,6 @@ impl From<physx_sys::PxTransform> for PxTransform {
 impl From<PxTransform> for physx_sys::PxTransform {
     fn from(value: PxTransform) -> Self {
         value.obj
-    }
-}
-
-impl From<Mat4> for PxTransform {
-    fn from(mat: Mat4) -> Self {
-        let (_, rotation, translation) = mat.to_scale_rotation_translation();
-        Self::from_translation_rotation(&translation.into(), &rotation.into())
-    }
-}
-
-impl From<PxTransform> for Mat4 {
-    fn from(value: PxTransform) -> Self {
-        Self::from_rotation_translation(value.rotation().into(), value.translation().into())
     }
 }
 

--- a/physx/src/math/vec3.rs
+++ b/physx/src/math/vec3.rs
@@ -1,5 +1,3 @@
-use glam::Vec3;
-
 use crate::traits::Class;
 
 use physx_sys::{
@@ -12,7 +10,7 @@ use physx_sys::{
 #[derive(Copy, Clone)]
 #[repr(transparent)]
 pub struct PxVec3 {
-    obj: physx_sys::PxVec3,
+    pub(super) obj: physx_sys::PxVec3,
 }
 
 crate::DeriveClassForNewType!(PxVec3: PxVec3);
@@ -54,20 +52,6 @@ impl From<PxVec3> for physx_sys::PxExtendedVec3 {
             y: value.obj.y as f64,
             z: value.obj.z as f64,
         }
-    }
-}
-
-impl From<Vec3> for PxVec3 {
-    fn from(v: Vec3) -> Self {
-        let (x, y, z) = v.into();
-        Self::new(x, y, z)
-    }
-}
-
-impl From<PxVec3> for Vec3 {
-    fn from(value: PxVec3) -> Self {
-        let physx_sys::PxVec3 { x, y, z } = value.obj;
-        Vec3::new(x, y, z)
     }
 }
 


### PR DESCRIPTION
Currently upgrading rust-gpu in Ark is usually blocked on physx-rs because Ark disallows duplicate deps and glam's minor version number changes often. This PR changes it so `glam` is optional dependency of `physx`, which should allow Ark to not depend on `glam` from `physx`.