### PR TITLE
Upgrade from Xcode 11.7 to 12.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest]
     env:
-      DEVELOPER_DIR: /Applications/Xcode_11.7.app
+      DEVELOPER_DIR: /Applications/Xcode_12.4.app
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v1
@@ -89,7 +89,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest]
     env:
-      DEVELOPER_DIR: /Applications/Xcode_11.7.app
+      DEVELOPER_DIR: /Applications/Xcode_12.4.app
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v1
@@ -139,7 +139,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-2019, macOS-latest]
     env:
-      DEVELOPER_DIR: /Applications/Xcode_11.7.app
+      DEVELOPER_DIR: /Applications/Xcode_12.4.app
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v1
@@ -159,7 +159,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-2019, macOS-latest]
     env:
-      DEVELOPER_DIR: /Applications/Xcode_11.7.app
+      DEVELOPER_DIR: /Applications/Xcode_12.4.app
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
Quick test to upgrade to 12.4, before upgrading to 12.5. https://github.com/NVIDIAGameWorks/PhysX/issues/321

Although failed on the `alloca` warning when building with cmake, which is odd as @XAMPPRocky added specific code to force disable that warning 3 months ago for the cmake path:

```
        // Currently there's bugs when compiling with the latest clang.
        // See: https://github.com/NVIDIAGameWorks/PhysX/issues/321
        .cxxflag("-Wno-alloca")
```

We do need to get CI in this repo to use/verify latest Xcode 