### PR TITLE
Fixup licenses

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,7 +62,7 @@ jobs:
       - name: ball no features
         run: cargo run --example ball
       - name: ball just cmake
-        run: cargo run --manifest-path physx/Cargo.toml --exmaple ball_physx --features use-cmake
+        run: cargo run --manifest-path physx/Cargo.toml --example ball_physx --features use-cmake
       - name: ball just structgen
         run: cargo run --manifest-path physx/Cargo.toml --example ball_physx --features structgen
 
@@ -92,7 +92,7 @@ jobs:
       - name: ball no features
         run: cargo run --example ball --release
       - name: ball just cmake
-        run: cargo run --manifest-path physx/Cargo.toml --exmaple ball_physx --features use-cmake --release
+        run: cargo run --manifest-path physx/Cargo.toml --example ball_physx --features use-cmake --release
       - name: ball just structgen
         run: cargo run --manifest-path physx/Cargo.toml --example ball_physx --features structgen --release
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -186,5 +186,4 @@ jobs:
           CC_aarch64_linux_android: ${{env.ANDROID_NDK_ROOT }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android29-clang
           CXX_aarch64_linux_android: ${{env.ANDROID_NDK_ROOT }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android29-clang++
           AR_aarch64_linux_android: ${{env.ANDROID_NDK_ROOT }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ar
-        uses: actions-rs/cargo@v1
         run: cargo build --target aarch64-linux-android --release

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,13 +1,22 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "*"
+  pull_request:
+
 name: CI
 env:
   ANDROID_NDK_ROOT: /usr/local/lib/android/sdk/ndk-bundle
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -15,163 +24,113 @@ jobs:
 
       # make sure all code has been formatted with rustfmt
       - run: rustup component add rustfmt
-      - run: git submodule update --init
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check --color always
+      - run: cargo fmt -- --check --color always
 
       # run clippy to verify we have no warnings
       - run: rustup component add clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-features -- -D warnings
+      - run: cargo clippy --all-features --all-targets -- -D warnings
 
   cargo-deny:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: EmbarkStudios/cargo-deny-action@v1
 
   test_debug:
     name: Test (Debug)
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-20.04, macOS-latest]
     env:
       DEVELOPER_DIR: /Applications/Xcode_11.7.app
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           override: true
-      - run: git submodule update --init
-      - name: cargo fetch
-        uses: actions-rs/cargo@v1
-        with:
-          command: fetch
+      - run: cargo fetch
       - name: test - no features
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+        run: cargo test
       - name: test - cmake + structgen
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features
+        run: cargo test --all-features
       - name: ball cmake + structgen
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --example ball --all-features
+        run: cargo run --example ball --all-features
       - name: ball no features
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --example ball
+        run: cargo run --example ball
       - name: ball just cmake
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --manifest-path physx/Cargo.toml --example ball_physx --features use-cmake
+        run: cargo run --manifest-path physx/Cargo.toml --exmaple ball_physx --features use-cmake
       - name: ball just structgen
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --manifest-path physx/Cargo.toml --example ball_physx --features structgen
+        run: cargo run --manifest-path physx/Cargo.toml --example ball_physx --features structgen
 
   test_release:
     name: Test (Release)
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-20.04, macOS-latest]
     env:
       DEVELOPER_DIR: /Applications/Xcode_11.7.app
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           override: true
-      - run: git submodule update --init
-      - name: cargo fetch
-        uses: actions-rs/cargo@v1
-        with:
-          command: fetch
+      - run: cargo fetch
       - name: test - no features
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release
+        run: cargo test --release
       - name: test - cmake + structgen
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features --release
+        run: cargo test --all-features --release
       - name: ball cmake + structgen
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --example ball --all-features --release
+        run: cargo run --example ball --all-features --release
       - name: ball no features
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --example ball --release
+        run: cargo run --example ball --release
       - name: ball just cmake
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --manifest-path physx/Cargo.toml --example ball_physx --features use-cmake --release
+        run: cargo run --manifest-path physx/Cargo.toml --exmaple ball_physx --features use-cmake --release
       - name: ball just structgen
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --manifest-path physx/Cargo.toml --example ball_physx --features structgen --release
+        run: cargo run --manifest-path physx/Cargo.toml --example ball_physx --features structgen --release
 
   package:
     name: Package
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-2019, macOS-latest]
+        os: [ubuntu-20.04, windows-2019, macOS-latest]
     env:
       DEVELOPER_DIR: /Applications/Xcode_11.7.app
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           override: true
-      - run: git submodule update --init
-      - uses: actions-rs/cargo@v1
-        with:
-          command: package
-          args: --manifest-path ./physx-sys/Cargo.toml
+      - run: cargo package --manifest-path ./physx-sys/Cargo.toml
 
   structgen:
     name: Structgen
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-2019, macOS-latest]
+        os: [ubuntu-20.04, windows-2019, macOS-latest]
     env:
       DEVELOPER_DIR: /Applications/Xcode_11.7.app
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           override: true
-      - run: git submodule update --init
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --manifest-path ./physx-sys/Cargo.toml --features structgen
+      - run: cargo build --manifest-path ./physx-sys/Cargo.toml --features structgen
       - name: Upload
         shell: bash
         run: |
@@ -189,45 +148,38 @@ jobs:
 
   build_android_debug:
     name: Build (Debug) (aarch64-linux-android)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           override: true
-      - run: git submodule update --init
       - run: rustup target add aarch64-linux-android
-      - name: cargo fetch
-        uses: actions-rs/cargo@v1
-        with:
-          command: fetch
+      - run: cargo fetch
       - name: build - no features
         env:
           LD_aarch64_linux_android: ${{env.ANDROID_NDK_ROOT }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ld
           CC_aarch64_linux_android: ${{env.ANDROID_NDK_ROOT }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android29-clang
           CXX_aarch64_linux_android: ${{env.ANDROID_NDK_ROOT }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android29-clang++
           AR_aarch64_linux_android: ${{env.ANDROID_NDK_ROOT }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ar
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --target aarch64-linux-android
+        run: cargo build --target aarch64-linux-android
 
   build_android_release:
     name: Build (Release) (aarch64-linux-android)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           override: true
-      - run: git submodule update --init
       - run: rustup target add aarch64-linux-android
-      - name: cargo fetch
-        uses: actions-rs/cargo@v1
-        with:
-          command: fetch
+      - run: cargo fetch
       - name: build - no features
         env:
           LD_aarch64_linux_android: ${{env.ANDROID_NDK_ROOT }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ld
@@ -235,38 +187,4 @@ jobs:
           CXX_aarch64_linux_android: ${{env.ANDROID_NDK_ROOT }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android29-clang++
           AR_aarch64_linux_android: ${{env.ANDROID_NDK_ROOT }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ar
         uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --target aarch64-linux-android --release
-#  android_structgen:
-#    name: Structgen (aarch64-linux-android)
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v1
-#      - uses: actions-rs/toolchain@v1
-#        with:
-#          toolchain: stable
-#          override: true
-#      - run: git submodule update --init
-#      - run: rustup target add aarch64-linux-android
-#      - run: sudo apt-get install libclang-9-dev
-#      - name: build & run pxbind
-#        env:
-#          LD_aarch64_linux_android: ${{env.ANDROID_NDK_ROOT }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ld
-#          CC_aarch64_linux_android: ${{env.ANDROID_NDK_ROOT }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android29-clang
-#          CXX_aarch64_linux_android: ${{env.ANDROID_NDK_ROOT }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android29-clang++
-#          AR_aarch64_linux_android: ${{env.ANDROID_NDK_ROOT }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ar
-#        run: export CC=/usr/bin/clang && export CXX=/usr/bin/clang++ && cd physx-sys/pxbind && ./build.sh && echo build succeeded && ./run_android.sh
-#      - name: Upload
-#        shell: bash
-#        run: |
-#          # Copy the structgen output to a deterministic location
-#          rs=$(find physx-sys/src/ -name physx_generated.rs)
-#          hpp=$(find physx-sys/src/ -name physx_generated.hpp)
-#          mkdir ./structgen
-#          cp $rs ./structgen/structgen.rs
-#          cp $hpp ./structgen/structgen_out.hpp
-#      - uses: actions/upload-artifact@v1
-#        with:
-#          name: structgen-aarch64-linux-android
-#          path: structgen
+        run: cargo build --target aarch64-linux-android --release

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,3 +1,5 @@
+Copyright (c) 2021 Embark Studios
+
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated
 documentation files (the "Software"), to deal in the

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
+<div align="center">
+
 # 🎳 physx-rs
+
+**Rust binding and wrapper over [NVIDIA PhysX](https://github.com/NVIDIAGameWorks/PhysX), a popular and mature physics engine particularly well-suited for games.**
 
 [![Embark](https://img.shields.io/badge/embark-open%20source-blueviolet.svg)](https://embark.dev)
 [![Embark](https://img.shields.io/badge/discord-ark-%237289da.svg?logo=discord)](https://discord.gg/dAuKfZS)
@@ -7,7 +11,7 @@
 [![dependency status](https://deps.rs/repo/github/EmbarkStudios/physx-rs/status.svg)](https://deps.rs/repo/github/EmbarkStudios/physx-rs)
 [![Build status](https://github.com/EmbarkStudios/physx-rs/workflows/CI/badge.svg)](https://github.com/EmbarkStudios/physx-rs/actions)
 
-Rust binding and wrapper over [NVIDIA PhysX](https://github.com/NVIDIAGameWorks/PhysX), a popular and mature physics engine particularly well-suited for games.
+</div>
 
 Created and maintained by [Embark](http://embark.games) and _**not**_ officially supported by NVIDIA.
 
@@ -17,7 +21,6 @@ This repository contains 2 crates:
 | --- | --- | --- |
 | [`physx`](physx/) | High-level interface on top of `physx-sys` 🚧 | [![Crates.io](https://img.shields.io/crates/v/physx.svg)](https://crates.io/crates/physx) [![Docs](https://docs.rs/physx/badge.svg)](https://docs.rs/physx) |
 | [`physx-sys`](physx-sys/) | Unsafe bindings to the [PhysX C++ API](https://github.com/NVIDIAGameWorks/PhysX) | [![Crates.io](https://img.shields.io/crates/v/physx-sys.svg)](https://crates.io/crates/physx-sys) [![Docs](https://docs.rs/physx-sys/badge.svg)](https://docs.rs/physx-sys) |
-
 
 ## Why use it?
 
@@ -41,13 +44,13 @@ This repository contains 2 crates:
 
 [Tomasz Stachowiak](https://github.com/h3r2tic) did a presentation at the Stockholm Rust Meetup on October 2019 about this project that goes through the tecnical details of how C++ to Rust bindings of `physx-sys` works:
 
-[![](http://img.youtube.com/vi/RxtXGeDHu0w/0.jpg)](http://www.youtube.com/watch?v=RxtXGeDHu0w "An unholy fusion of Rust and C++ in physx-rs (Stockholm Rust Meetup, October 2019)")
+[![An unholy fusion of Rust and C++ in physx-rs (Stockholm Rust Meetup, October 2019)](http://img.youtube.com/vi/RxtXGeDHu0w/0.jpg)](http://www.youtube.com/watch?v=RxtXGeDHu0w)
 
 ## Usage
 
 The following code example shows how [`physx`](physx/) can be initialized.
 
-``` Rust
+``` rust
 const PX_PHYSICS_VERSION: u32 = physx::version(4, 1, 1);
 let mut foundation = Foundation::new(PX_PHYSICS_VERSION);
 
@@ -94,13 +97,9 @@ debug = false
 ## How to release (maintainers only)
 
 1. Install [cargo-release](https://github.com/sunng87/cargo-release#install)
-
-2. Look at `physx/CHANGELOG.md` and `physx-sys/CHANGELOG.md` to determine whether both or only one
-of the crate needs updating, and what [semantic version](https://semver.org/) bump we need
-
-2. Review the list of changes in the changelogs and compare with the git commit diffs to the previous release and make sure we've captured and described all changes well and that they are semantically correct
-
-3. Run `cargo release --manifest-path <physx|physx-sys>/Cargo.toml <major|minor|patch>` to automatically update the CHANGELOG, publish, tag, and push the release. If you are publishing both `physx` and `physx-sys`, you can just add the `--skip-push` flag to avoid pushing each crate individually and then do `git push --follow-tags` to push both at the same time.
+2. Look at `physx/CHANGELOG.md` and `physx-sys/CHANGELOG.md` to determine whether both or only one of the crate needs updating, and what [semantic version](https://semver.org/) bump we need
+3. Review the list of changes in the changelogs and compare with the git commit diffs to the previous release and make sure we've captured and described all changes well and that they are semantically correct
+4. Run `cargo release --manifest-path <physx|physx-sys>/Cargo.toml <major|minor|patch>` to automatically update the CHANGELOG, publish, tag, and push the release. If you are publishing both `physx` and `physx-sys`, you can just add the `--skip-push` flag to avoid pushing each crate individually and then do `git push --follow-tags` to push both at the same time.
 
 ## Contributing
 
@@ -114,8 +113,8 @@ Please read our [Contributor Guide](CONTRIBUTING.md) for more information on how
 
 Licensed under either of
 
-* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
-* MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+* MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 
 at your option.
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,13 +1,13 @@
 [bans]
 multiple-versions = "deny"
 deny = [
-    { name = "openssl" },   
+    { name = "openssl" },
 
     # library choices we've made
-    { name = "nalgebra" },          # we use glam as math library, not nalgebra 
-    { name = "nalgebra-glm" },      # we use glam as math library, not nalgebra 
-    { name = "ncollide3d"},         # we use PhysX, not nphysics/nalgebra 
-    { name = "nphysics"},           # we use PhysX, not nphysics/nalgebra 
+    { name = "nalgebra" },     # we use glam as math library, not nalgebra 
+    { name = "nalgebra-glm" }, # we use glam as math library, not nalgebra 
+    { name = "ncollide3d" },   # we use PhysX, not nphysics/nalgebra 
+    { name = "nphysics" },     # we use PhysX, not nphysics/nalgebra 
 
     # deprecated/abandoned
     { name = "term" },              # term is not fully maintained, and termcolor is replacing it
@@ -15,27 +15,15 @@ deny = [
     { name = "build-helper" },      # abandoned, and doesn't add much value
     { name = "app_dirs" },          # abandoned, use app_dirs2 instead
     { name = "colored" },           # not actively maintained? slow to merge update fixes in and has lots of old dependencies
-    { name = "floating-duration"},  # not needed with Rust 1.38, and very few users and commits
-    { name = "mopa"},               # abandoned, have not been updated for 4 years
+    { name = "floating-duration" }, # not needed with Rust 1.38, and very few users and commits
+    { name = "mopa" },              # abandoned, have not been updated for 4 years
 ]
-skip = [
-]
-skip-tree = [
-]
+skip = []
+skip-tree = []
 
 [licenses]
 unlicensed = "deny"
 allow-osi-fsf-free = "neither"
 # We want really high confidence when inferring licenses from text
 confidence-threshold = 0.92
-allow = [
-    "LicenseRef-Embark-Proprietary",
-    "Apache-2.0",
-    "Apache-2.0 WITH LLVM-exception",
-    "BSD-2-Clause",
-    "BSD-3-Clause",
-    "ISC",
-    "MIT",
-    "MPL-2.0",
-    "Zlib",
-]
+allow = ["Apache-2.0", "BSD-3-Clause", "MIT"]

--- a/deny.toml
+++ b/deny.toml
@@ -27,3 +27,8 @@ allow-osi-fsf-free = "neither"
 # We want really high confidence when inferring licenses from text
 confidence-threshold = 0.92
 allow = ["Apache-2.0", "BSD-3-Clause", "MIT"]
+
+[[licenses.clarify]]
+name = "physx-sys"
+expression = "(MIT OR Apache-2.0) AND BSD-3-Clause"
+license-files = [{ path = "LICENSE", hash = 0xe326546e }]

--- a/physx-sys/CHANGELOG.md
+++ b/physx-sys/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Fixed
+
+- [PR#142](https://github.com/EmbarkStudios/physx-rs/pull/141) added the license texts to the crate, and added a note in the README about how to clarify the licenses in cargo deny until crates.io supports parentheses in license expressions.
+
 ## [0.4.15] - 2021-08-22
 
 ### Changed

--- a/physx-sys/Cargo.toml
+++ b/physx-sys/Cargo.toml
@@ -2,8 +2,11 @@
 name = "physx-sys"
 description = "Unsafe bindings for NVIDIA PhysX C++ SDK"
 version = "0.4.15"
-authors = ["Embark <opensource@embark-studios.com>", "Tomasz Stachowiak <h3@h3.gd>"]
-license = "MIT OR Apache-2.0"
+authors = [
+    "Embark <opensource@embark-studios.com>",
+    "Tomasz Stachowiak <h3@h3.gd>",
+]
+license = "(MIT OR Apache-2.0) AND BSD-3-Clause"
 repository = "https://github.com/EmbarkStudios/physx-rs"
 edition = "2018"
 build = "build.rs"

--- a/physx-sys/Cargo.toml
+++ b/physx-sys/Cargo.toml
@@ -6,7 +6,9 @@ authors = [
     "Embark <opensource@embark-studios.com>",
     "Tomasz Stachowiak <h3@h3.gd>",
 ]
-license = "(MIT OR Apache-2.0) AND BSD-3-Clause"
+# we need to wait until crates.io supports parentheses https://github.com/rust-lang/crates.io/issues/2595
+#license = "(MIT OR Apache-2.0) AND BSD-3-Clause"
+license-file = "LICENSE"
 repository = "https://github.com/EmbarkStudios/physx-rs"
 edition = "2018"
 build = "build.rs"

--- a/physx-sys/LICENSE
+++ b/physx-sys/LICENSE
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: (MIT OR Apache-2.0) AND BSD-3-Clause

--- a/physx-sys/LICENSE-APACHE
+++ b/physx-sys/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/physx-sys/LICENSE-BSD
+++ b/physx-sys/LICENSE-BSD
@@ -1,0 +1,25 @@
+Copyright (c) 2019 NVIDIA Corporation. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+ * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ * Neither the name of NVIDIA CORPORATION nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/physx-sys/LICENSE-MIT
+++ b/physx-sys/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2021 Embark Studios
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/physx-sys/README.md
+++ b/physx-sys/README.md
@@ -1,4 +1,8 @@
+<div align="center">
+
 # 🎳 physx-sys
+
+**Unsafe automatically-generated Rust bindings for [NVIDIA PhysX 4.1](https://github.com/NVIDIAGameWorks/PhysX) C++ API.**
 
 ![Build Status](https://github.com/EmbarkStudios/physx-rs/workflows/CI/badge.svg)
 [![Crates.io](https://img.shields.io/crates/v/physx-sys.svg)](https://crates.io/crates/physx-sys)
@@ -7,7 +11,7 @@
 [![Embark](https://img.shields.io/badge/embark-open%20source-blueviolet.svg)](http://embark.games)
 [![Embark](https://img.shields.io/badge/discord-ark-%237289da.svg?logo=discord)](https://discord.gg/dAuKfZS)
 
-Unsafe automatically-generated Rust bindings for [NVIDIA PhysX 4.1](https://github.com/NVIDIAGameWorks/PhysX) C++ API.
+</div>
 
 Please also see the [repository](https://github.com/EmbarkStudios/physx-rs) containing a work-in-progress safe wrapper.
 
@@ -15,11 +19,11 @@ Please also see the [repository](https://github.com/EmbarkStudios/physx-rs) cont
 
 [Tomasz Stachowiak](https://github.com/h3r2tic) did a presentation at the Stockholm Rust Meetup on October 2019 about this project that goes through the technical details of how C++ to Rust bindings of `physx-sys` works:
 
-[![](http://img.youtube.com/vi/RxtXGeDHu0w/0.jpg)](http://www.youtube.com/watch?v=RxtXGeDHu0w "An unholy fusion of Rust and C++ in physx-rs (Stockholm Rust Meetup, October 2019)")
+[![An unholy fusion of Rust and C++ in physx-rs (Stockholm Rust Meetup, October 2019)](http://img.youtube.com/vi/RxtXGeDHu0w/0.jpg)](http://www.youtube.com/watch?v=RxtXGeDHu0w)
 
 ## Basic usage
 
-```Rust
+```rust
 unsafe {
     let foundation = physx_create_foundation();
     let physics = physx_create_physics(foundation);
@@ -48,7 +52,7 @@ unsafe {
 
 A simple example to showcase how to use physx-sys. It can be run with `cargo run --examples ball`.
 
-```
+```txt
  o
 
   o
@@ -90,12 +94,12 @@ Steps *2..4* are performed completely automatically from within `build.rs`, whil
 
 Licensed under either of
 
-* Apache License, Version 2.0, ([LICENSE-APACHE](../LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
-* MIT license ([LICENSE-MIT](../LICENSE-MIT) or http://opensource.org/licenses/MIT)
+* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+* MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 
 at your option.
 
-Note that the [PhysX C++ SDK](https://github.com/NVIDIAGameWorks/PhysX) has it's [own BSD 3 license](https://gameworksdocs.nvidia.com/PhysX/4.1/documentation/physxguide/Manual/License.html) and depends on [additional C++ third party libraries](https://github.com/NVIDIAGameWorks/PhysX/tree/4.1/externals).
+Note that the [PhysX C++ SDK](https://github.com/NVIDIAGameWorks/PhysX) has its [own BSD 3 license](https://gameworksdocs.nvidia.com/PhysX/4.1/documentation/physxguide/Manual/License.html) and depends on [additional C++ third party libraries](https://github.com/NVIDIAGameWorks/PhysX/tree/4.1/externals).
 
 ### Contribution
 

--- a/physx-sys/README.md
+++ b/physx-sys/README.md
@@ -101,6 +101,15 @@ at your option.
 
 Note that the [PhysX C++ SDK](https://github.com/NVIDIAGameWorks/PhysX) has its [own BSD 3 license](https://gameworksdocs.nvidia.com/PhysX/4.1/documentation/physxguide/Manual/License.html) and depends on [additional C++ third party libraries](https://github.com/NVIDIAGameWorks/PhysX/tree/4.1/externals).
 
+If you use [`cargo deny`](https://github.com/EmbarkStudios/cargo-deny), you can use this clarification in your configuration, at least until [crates.io supports parentheses](https://github.com/rust-lang/crates.io/issues/2595).
+
+```ini
+[[licenses.clarify]]
+name = "physx-sys"
+expression = "(MIT OR Apache-2.0) AND BSD-3-Clause"
+license-files = [{ path = "LICENSE", hash = 0xe326546e }]
+```
+
 ### Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally

--- a/physx-sys/src/lib.rs
+++ b/physx-sys/src/lib.rs
@@ -122,7 +122,7 @@
 //! license, shall be dual licensed as above, without any additional terms or
 //! conditions.
 
-// BEGIN - Embark standard lints v0.4
+// BEGIN - Embark standard lints v5 for Rust 1.55+
 // do not change or add/remove here, but one can add exceptions after this section
 // for more info see: <https://github.com/EmbarkStudios/rust-ecosystem/issues/59>
 #![deny(unsafe_code)]
@@ -133,6 +133,8 @@
     clippy::checked_conversions,
     clippy::dbg_macro,
     clippy::debug_assert_with_mut_call,
+    clippy::disallowed_method,
+    clippy::disallowed_type,
     clippy::doc_markdown,
     clippy::empty_enum,
     clippy::enum_glob_use,
@@ -142,13 +144,17 @@
     clippy::explicit_into_iter_loop,
     clippy::fallible_impl_from,
     clippy::filter_map_next,
+    clippy::flat_map_option,
     clippy::float_cmp_const,
     clippy::fn_params_excessive_bools,
+    clippy::from_iter_instead_of_collect,
     clippy::if_let_mutex,
     clippy::implicit_clone,
     clippy::imprecise_flops,
     clippy::inefficient_to_string,
     clippy::invalid_upcast_comparisons,
+    clippy::large_digit_groups,
+    clippy::large_stack_arrays,
     clippy::large_types_passed_by_value,
     clippy::let_unit_value,
     clippy::linkedlist,
@@ -160,20 +166,25 @@
     clippy::map_unwrap_or,
     clippy::match_on_vec_items,
     clippy::match_same_arms,
+    clippy::match_wild_err_arm,
     clippy::match_wildcard_for_single_variants,
     clippy::mem_forget,
     clippy::mismatched_target_os,
+    clippy::missing_enforced_import_renames,
     clippy::mut_mut,
     clippy::mutex_integer,
     clippy::needless_borrow,
     clippy::needless_continue,
+    clippy::needless_for_each,
     clippy::option_option,
     clippy::path_buf_push_overwrite,
     clippy::ptr_as_ptr,
+    clippy::rc_mutex,
     clippy::ref_option_ref,
     clippy::rest_pat_in_fully_bound_structs,
     clippy::same_functions_in_if_condition,
     clippy::semicolon_if_nothing_returned,
+    clippy::single_match_else,
     clippy::string_add_assign,
     clippy::string_add,
     clippy::string_lit_as_bytes,
@@ -190,7 +201,7 @@
     nonstandard_style,
     rust_2018_idioms
 )]
-// END - Embark standard lints v0.4
+// END - Embark standard lints v0.5 for Rust 1.55+
 // crate-specific exceptions:
 #![allow(
     unsafe_code,

--- a/physx/LICENSE-APACHE
+++ b/physx/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/physx/LICENSE-MIT
+++ b/physx/LICENSE-MIT
@@ -1,0 +1,23 @@
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/physx/src/foundation.rs
+++ b/physx/src/foundation.rs
@@ -144,7 +144,8 @@ impl ScratchBuffer {
     }
 
     /// # Safety
-    /// the buffer must live at least until fetch_results returns.
+    ///
+    /// The buffer must live at least until fetch_results returns.
     pub unsafe fn new(nb_blocks: usize) -> Self {
         let size = size_of::<ScratchBufferBlock>() * nb_blocks;
         let align = align_of::<ScratchBufferBlock>();
@@ -156,10 +157,12 @@ impl ScratchBuffer {
 /// A trait for creating allocator callbacks for PhysX.
 ///
 /// Reporting the name, file and line is not enabled by default.
-/// Use `set_report_allocation_names` to toggle this on or off.
+/// Use [`Foundation::set_report_allocation_names`] to toggle this on or off.
+#[allow(clippy::missing_safety_doc)]
 pub unsafe trait AllocatorCallback: Sized {
     /// # Safety
-    /// allocations must be align 16.  This should not panic, since it is
+    ///
+    /// Allocations must be aligned 16. This should not panic, since it is
     /// called in an FFI context and unwinding across the FFI barrier is UB.
     unsafe extern "C" fn allocate(
         size: u64,
@@ -170,11 +173,13 @@ pub unsafe trait AllocatorCallback: Sized {
     ) -> *mut c_void;
 
     /// # Safety
-    /// must not panic.
+    ///
+    /// Must not panic.
     unsafe extern "C" fn deallocate(ptr: *const c_void, user_data: *const c_void);
 
     /// # Safety
-    /// do not override this method.
+    ///
+    /// Do not override this method.
     unsafe fn into_px(self) -> *mut PxAllocatorCallback {
         create_alloc_callback(
             Self::allocate,

--- a/physx/src/lib.rs
+++ b/physx/src/lib.rs
@@ -93,7 +93,7 @@
 //! license, shall be dual licensed as above, without any additional terms or
 //! conditions.
 
-// BEGIN - Embark standard lints v0.4
+// BEGIN - Embark standard lints v5 for Rust 1.55+
 // do not change or add/remove here, but one can add exceptions after this section
 // for more info see: <https://github.com/EmbarkStudios/rust-ecosystem/issues/59>
 #![deny(unsafe_code)]
@@ -104,6 +104,8 @@
     clippy::checked_conversions,
     clippy::dbg_macro,
     clippy::debug_assert_with_mut_call,
+    clippy::disallowed_method,
+    clippy::disallowed_type,
     clippy::doc_markdown,
     clippy::empty_enum,
     clippy::enum_glob_use,
@@ -113,13 +115,17 @@
     clippy::explicit_into_iter_loop,
     clippy::fallible_impl_from,
     clippy::filter_map_next,
+    clippy::flat_map_option,
     clippy::float_cmp_const,
     clippy::fn_params_excessive_bools,
+    clippy::from_iter_instead_of_collect,
     clippy::if_let_mutex,
     clippy::implicit_clone,
     clippy::imprecise_flops,
     clippy::inefficient_to_string,
     clippy::invalid_upcast_comparisons,
+    clippy::large_digit_groups,
+    clippy::large_stack_arrays,
     clippy::large_types_passed_by_value,
     clippy::let_unit_value,
     clippy::linkedlist,
@@ -131,20 +137,25 @@
     clippy::map_unwrap_or,
     clippy::match_on_vec_items,
     clippy::match_same_arms,
+    clippy::match_wild_err_arm,
     clippy::match_wildcard_for_single_variants,
     clippy::mem_forget,
     clippy::mismatched_target_os,
+    clippy::missing_enforced_import_renames,
     clippy::mut_mut,
     clippy::mutex_integer,
     clippy::needless_borrow,
     clippy::needless_continue,
+    clippy::needless_for_each,
     clippy::option_option,
     clippy::path_buf_push_overwrite,
     clippy::ptr_as_ptr,
+    clippy::rc_mutex,
     clippy::ref_option_ref,
     clippy::rest_pat_in_fully_bound_structs,
     clippy::same_functions_in_if_condition,
     clippy::semicolon_if_nothing_returned,
+    clippy::single_match_else,
     clippy::string_add_assign,
     clippy::string_add,
     clippy::string_lit_as_bytes,
@@ -161,8 +172,7 @@
     nonstandard_style,
     rust_2018_idioms
 )]
-// END - Embark standard lints v0.4
-// crate-specific exceptions:
+// END - Embark standard lints v0.5 for Rust 1.55+
 #![allow(
     unsafe_code,                            // this is a safe wrapper of unsafe code, so plenty of unsafe code in here
     clippy::doc_markdown,                   // TODO: fixup comments and docs (though annoyingly complains about "PhysX")


### PR DESCRIPTION
- The MIT license was missing the Embark Studios copyright
- The physx-sys crate wasn't packaging the license files since they weren't in the crate root, so just copied them there
- Added the BSD-3-Clause license text from PhysX into the root as well
- Fixed the license expression for the -sys crate to `(MIT OR Apache-2.0) AND BSD-3-Clause` as the Rust code is licensed under MIT OR Apache-2.0, but the C++ code is under the BSD-3-Clause
- Updated README to fix various issues and just generally spruce it up