### PR TITLE
Upgrade glam from 0.13 to 0.20 (optional dependency)

### DIFF
--- a/physx/Cargo.toml
+++ b/physx/Cargo.toml
@@ -18,7 +18,7 @@ physx-sys = { version = "0.4.10", path = "../physx-sys" }
 
 enumflags2 = "0.7"
 log = "0.4"
-glam = { version = "0.13", optional = true }
+glam = { version = "0.20", optional = true }
 thiserror = "1.0"
 
 [features]

--- a/physx/src/math/mod.rs
+++ b/physx/src/math/mod.rs
@@ -15,9 +15,7 @@ pub use quat::PxQuat;
 mod vec3;
 pub use vec3::PxVec3;
 #[cfg(feature = "glam")]
-pub mod glam;
-#[cfg(feature = "glam")]
-pub use self::glam::*;
+mod glam;
 
 #[derive(Copy, Clone)]
 #[repr(transparent)]

--- a/physx/src/math/mod.rs
+++ b/physx/src/math/mod.rs
@@ -16,6 +16,8 @@ mod vec3;
 pub use vec3::PxVec3;
 #[cfg(feature = "glam")]
 mod glam;
+#[cfg(feature = "glam")]
+pub use glam::*;
 
 #[derive(Copy, Clone)]
 #[repr(transparent)]

--- a/physx/src/math/mod.rs
+++ b/physx/src/math/mod.rs
@@ -16,6 +16,8 @@ mod vec3;
 pub use vec3::PxVec3;
 #[cfg(feature = "glam")]
 pub mod glam;
+#[cfg(feature = "glam")]
+pub use self::glam::*;
 
 #[derive(Copy, Clone)]
 #[repr(transparent)]

--- a/physx/src/math/mod.rs
+++ b/physx/src/math/mod.rs
@@ -15,9 +15,7 @@ pub use quat::PxQuat;
 mod vec3;
 pub use vec3::PxVec3;
 #[cfg(feature = "glam")]
-mod glam;
-#[cfg(feature = "glam")]
-pub use glam::*;
+pub mod glam;
 
 #[derive(Copy, Clone)]
 #[repr(transparent)]


### PR DESCRIPTION
The version of glam is quite outdated (~11 mo), and makes it difficult to use conversions for those that use the optional "glam" feature.