### PR TITLE
Update supported clang/llvm for pxbind

### DIFF
--- a/physx-sys/README.md
+++ b/physx-sys/README.md
@@ -90,6 +90,8 @@ The build process comprises a few steps:
 
 Steps *2..4* are performed completely automatically from within `build.rs`, while step *1* is only necessary when upgrading the PhysX SDK or modifying the generator. As such, building and running `pxbind` is a manual task, and is currently only supported on \*nix systems.
 
+Since `pxbind` relies on unstable clang internals only specific clang/llvm versions are supported to build it. Currently supported versions are `llvm-14` and `libclang-14-dev`. You may find it working with other versions but it's not guarenteed.
+
 ## License
 
 Licensed under either of

--- a/physx-sys/pxbind/CMakeLists.txt
+++ b/physx-sys/pxbind/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.8)
+cmake_minimum_required(VERSION 3.1)
 project(pxbind)
 
 # Allow the user to override the install prefix.
@@ -7,7 +7,7 @@ if(NOT DEFINED CMAKE_INSTALL_PREFIX)
 endif()
 string(REGEX REPLACE "/$" "" CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
 
-find_package(LLVM REQUIRED CONFIG)
+find_package(LLVM 14 REQUIRED CONFIG)
 
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
@@ -16,7 +16,7 @@ message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 # E.g. if using the C++ header files
 # you will need to enable C++11 support
 # for your compiler.
-SET( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -g")
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -g")
 
 include_directories(${LLVM_INCLUDE_DIRS})
 link_directories(${LLVM_LIBRARY_DIRS})
@@ -24,10 +24,12 @@ add_definitions(${LLVM_DEFINITIONS})
 
 # Now build our tools
 add_executable(pxbind main.cpp)
+# Get rid of warning when using clang, for whatever reason -std=c++17 above isn't enough
+set_property(TARGET pxbind PROPERTY CXX_STANDARD 17)
 
 # Find the libraries that correspond to the LLVM components
 # that we wish to use
-llvm_map_components_to_libnames(llvm_libs x86asmparser bitreader support mc option profiledata)
+llvm_map_components_to_libnames(llvm_libs x86asmparser bitreader support mc option profiledata frontendopenmp libdriver)
 message(STATUS "LLVM_LIBS: ${llvm_libs}")
 
 target_link_libraries(pxbind

--- a/physx-sys/pxbind/CMakeLists.txt
+++ b/physx-sys/pxbind/CMakeLists.txt
@@ -29,7 +29,7 @@ set_property(TARGET pxbind PROPERTY CXX_STANDARD 17)
 
 # Find the libraries that correspond to the LLVM components
 # that we wish to use
-llvm_map_components_to_libnames(llvm_libs x86asmparser bitreader support mc option profiledata frontendopenmp libdriver)
+llvm_map_components_to_libnames(llvm_libs x86asmparser bitreader support mc option profiledata frontendopenmp)
 message(STATUS "LLVM_LIBS: ${llvm_libs}")
 
 target_link_libraries(pxbind

--- a/physx-sys/src/generated/x86_64-apple-darwin/structgen.rs
+++ b/physx-sys/src/generated/x86_64-apple-darwin/structgen.rs
@@ -573,6 +573,15 @@ pub struct PxSpatialForce {
 #[test] fn check_size_PxSpatialForce() { assert_eq!(std::mem::size_of::<PxSpatialForce>(), 32); }
 #[derive(Clone, Copy)]
 #[repr(C)]
+pub struct PxSpatialVelocity {
+    pub linear: PxVec3,
+    pub pad0: f32,
+    pub angular: PxVec3,
+    pub pad1: f32,
+}
+#[test] fn check_size_PxSpatialVelocity() { assert_eq!(std::mem::size_of::<PxSpatialVelocity>(), 32); }
+#[derive(Clone, Copy)]
+#[repr(C)]
 pub struct PxArticulationRootLinkData {
     pub transform: PxTransform,
     pub worldLinVel: PxVec3,
@@ -591,14 +600,15 @@ pub struct PxArticulationCache {
     pub jointAcceleration: *mut f32,
     pub jointPosition: *mut f32,
     pub jointForce: *mut f32,
-    pub structgen_pad0: [u8; 16],
+    pub linkVelocity: *mut PxSpatialVelocity,
+    pub linkAcceleration: *mut PxSpatialVelocity,
     pub rootLinkData: *mut PxArticulationRootLinkData,
     pub coefficientMatrix: *mut f32,
     pub lambda: *mut f32,
     pub scratchMemory: *mut std::ffi::c_void,
     pub scratchAllocator: *mut std::ffi::c_void,
     pub version: u32,
-    pub structgen_pad1: [u8; 4],
+    pub structgen_pad0: [u8; 4],
 }
 #[test] fn check_size_PxArticulationCache() { assert_eq!(std::mem::size_of::<PxArticulationCache>(), 120); }
 #[derive(Clone, Copy)]

--- a/physx-sys/src/generated/x86_64-apple-darwin/structgen_out.hpp
+++ b/physx-sys/src/generated/x86_64-apple-darwin/structgen_out.hpp
@@ -493,6 +493,12 @@ struct physx_PxSpatialForce_Pod {
     physx_PxVec3_Pod torque;
     float pad1;
 };
+struct physx_PxSpatialVelocity_Pod {
+    physx_PxVec3_Pod linear;
+    float pad0;
+    physx_PxVec3_Pod angular;
+    float pad1;
+};
 struct physx_PxArticulationRootLinkData_Pod {
     physx_PxTransform_Pod transform;
     physx_PxVec3_Pod worldLinVel;
@@ -508,14 +514,15 @@ struct physx_PxArticulationCache_Pod {
     float* jointAcceleration;
     float* jointPosition;
     float* jointForce;
-    char structgen_pad0[16];
+    physx_PxSpatialVelocity_Pod* linkVelocity;
+    physx_PxSpatialVelocity_Pod* linkAcceleration;
     physx_PxArticulationRootLinkData_Pod* rootLinkData;
     float* coefficientMatrix;
     float* lambda;
     void* scratchMemory;
     void* scratchAllocator;
     uint32_t version;
-    char structgen_pad1[4];
+    char structgen_pad0[4];
 };
 struct physx_PxArticulationReducedCoordinate_Pod {
     char structgen_pad0[8];
@@ -836,7 +843,7 @@ struct physx_PxPvd_Pod {
     void* vtable_;
 };
 struct physx_PxRigidDynamicLockFlags_Pod {
-    uint16_t mBits;
+    unsigned char mBits;
 };
 struct physx_PxSimulationStatistics_Pod {
     uint32_t nbActiveConstraints;
@@ -1241,7 +1248,7 @@ struct physx_PxBVH33MidphaseDesc_Pod {
 struct physx_PxBVH34MidphaseDesc_Pod {
     uint32_t numPrimsPerLeaf;
 };
-struct Anonymous216_Pod {
+struct Anonymous217_Pod {
     physx_PxBVH33MidphaseDesc_Pod mBVH33Desc;
     physx_PxBVH34MidphaseDesc_Pod mBVH34Desc;
 };
@@ -1589,6 +1596,9 @@ struct physx_PxVehicleTireData_Pod {
 struct physx_PxVehicleWheels4SimData_Pod;
 struct physx_PxVehicleWheelsSimData_Pod {
     char structgen_pad0[96];
+};
+struct physx_PxVehicleWheelsSimFlags_Pod {
+    uint32_t mBits;
 };
 struct physx_PxVehicleWheels4DynData_Pod;
 struct physx_PxVehicleTireForceCalculator_Pod;

--- a/physx-sys/src/generated/x86_64-pc-windows-msvc/structgen.rs
+++ b/physx-sys/src/generated/x86_64-pc-windows-msvc/structgen.rs
@@ -575,6 +575,15 @@ pub struct PxSpatialForce {
 #[test] fn check_size_PxSpatialForce() { assert_eq!(std::mem::size_of::<PxSpatialForce>(), 32); }
 #[derive(Clone, Copy)]
 #[repr(C)]
+pub struct PxSpatialVelocity {
+    pub linear: PxVec3,
+    pub pad0: f32,
+    pub angular: PxVec3,
+    pub pad1: f32,
+}
+#[test] fn check_size_PxSpatialVelocity() { assert_eq!(std::mem::size_of::<PxSpatialVelocity>(), 32); }
+#[derive(Clone, Copy)]
+#[repr(C)]
 pub struct PxArticulationRootLinkData {
     pub transform: PxTransform,
     pub worldLinVel: PxVec3,
@@ -593,14 +602,15 @@ pub struct PxArticulationCache {
     pub jointAcceleration: *mut f32,
     pub jointPosition: *mut f32,
     pub jointForce: *mut f32,
-    pub structgen_pad0: [u8; 16],
+    pub linkVelocity: *mut PxSpatialVelocity,
+    pub linkAcceleration: *mut PxSpatialVelocity,
     pub rootLinkData: *mut PxArticulationRootLinkData,
     pub coefficientMatrix: *mut f32,
     pub lambda: *mut f32,
     pub scratchMemory: *mut std::ffi::c_void,
     pub scratchAllocator: *mut std::ffi::c_void,
     pub version: u32,
-    pub structgen_pad1: [u8; 4],
+    pub structgen_pad0: [u8; 4],
 }
 #[test] fn check_size_PxArticulationCache() { assert_eq!(std::mem::size_of::<PxArticulationCache>(), 120); }
 #[derive(Clone, Copy)]

--- a/physx-sys/src/generated/x86_64-pc-windows-msvc/structgen_out.hpp
+++ b/physx-sys/src/generated/x86_64-pc-windows-msvc/structgen_out.hpp
@@ -495,6 +495,12 @@ struct physx_PxSpatialForce_Pod {
     physx_PxVec3_Pod torque;
     float pad1;
 };
+struct physx_PxSpatialVelocity_Pod {
+    physx_PxVec3_Pod linear;
+    float pad0;
+    physx_PxVec3_Pod angular;
+    float pad1;
+};
 struct physx_PxArticulationRootLinkData_Pod {
     physx_PxTransform_Pod transform;
     physx_PxVec3_Pod worldLinVel;
@@ -510,14 +516,15 @@ struct physx_PxArticulationCache_Pod {
     float* jointAcceleration;
     float* jointPosition;
     float* jointForce;
-    char structgen_pad0[16];
+    physx_PxSpatialVelocity_Pod* linkVelocity;
+    physx_PxSpatialVelocity_Pod* linkAcceleration;
     physx_PxArticulationRootLinkData_Pod* rootLinkData;
     float* coefficientMatrix;
     float* lambda;
     void* scratchMemory;
     void* scratchAllocator;
     uint32_t version;
-    char structgen_pad1[4];
+    char structgen_pad0[4];
 };
 struct physx_PxArticulationReducedCoordinate_Pod {
     char structgen_pad0[8];
@@ -840,7 +847,7 @@ struct physx_PxPvd_Pod {
     void* vtable_;
 };
 struct physx_PxRigidDynamicLockFlags_Pod {
-    uint16_t mBits;
+    unsigned char mBits;
 };
 struct physx_PxSimulationStatistics_Pod {
     uint32_t nbActiveConstraints;
@@ -1249,7 +1256,7 @@ struct physx_PxBVH33MidphaseDesc_Pod {
 struct physx_PxBVH34MidphaseDesc_Pod {
     uint32_t numPrimsPerLeaf;
 };
-struct Anonymous216_Pod {
+struct Anonymous217_Pod {
     physx_PxBVH33MidphaseDesc_Pod mBVH33Desc;
     physx_PxBVH34MidphaseDesc_Pod mBVH34Desc;
 };
@@ -1597,6 +1604,9 @@ struct physx_PxVehicleTireData_Pod {
 struct physx_PxVehicleWheels4SimData_Pod;
 struct physx_PxVehicleWheelsSimData_Pod {
     char structgen_pad0[96];
+};
+struct physx_PxVehicleWheelsSimFlags_Pod {
+    uint32_t mBits;
 };
 struct physx_PxVehicleWheels4DynData_Pod;
 struct physx_PxVehicleTireForceCalculator_Pod;

--- a/physx-sys/src/generated/x86_64-unknown-linux/structgen.rs
+++ b/physx-sys/src/generated/x86_64-unknown-linux/structgen.rs
@@ -573,6 +573,15 @@ pub struct PxSpatialForce {
 #[test] fn check_size_PxSpatialForce() { assert_eq!(std::mem::size_of::<PxSpatialForce>(), 32); }
 #[derive(Clone, Copy)]
 #[repr(C)]
+pub struct PxSpatialVelocity {
+    pub linear: PxVec3,
+    pub pad0: f32,
+    pub angular: PxVec3,
+    pub pad1: f32,
+}
+#[test] fn check_size_PxSpatialVelocity() { assert_eq!(std::mem::size_of::<PxSpatialVelocity>(), 32); }
+#[derive(Clone, Copy)]
+#[repr(C)]
 pub struct PxArticulationRootLinkData {
     pub transform: PxTransform,
     pub worldLinVel: PxVec3,
@@ -591,14 +600,15 @@ pub struct PxArticulationCache {
     pub jointAcceleration: *mut f32,
     pub jointPosition: *mut f32,
     pub jointForce: *mut f32,
-    pub structgen_pad0: [u8; 16],
+    pub linkVelocity: *mut PxSpatialVelocity,
+    pub linkAcceleration: *mut PxSpatialVelocity,
     pub rootLinkData: *mut PxArticulationRootLinkData,
     pub coefficientMatrix: *mut f32,
     pub lambda: *mut f32,
     pub scratchMemory: *mut std::ffi::c_void,
     pub scratchAllocator: *mut std::ffi::c_void,
     pub version: u32,
-    pub structgen_pad1: [u8; 4],
+    pub structgen_pad0: [u8; 4],
 }
 #[test] fn check_size_PxArticulationCache() { assert_eq!(std::mem::size_of::<PxArticulationCache>(), 120); }
 #[derive(Clone, Copy)]

--- a/physx-sys/src/generated/x86_64-unknown-linux/structgen_out.hpp
+++ b/physx-sys/src/generated/x86_64-unknown-linux/structgen_out.hpp
@@ -493,6 +493,12 @@ struct physx_PxSpatialForce_Pod {
     physx_PxVec3_Pod torque;
     float pad1;
 };
+struct physx_PxSpatialVelocity_Pod {
+    physx_PxVec3_Pod linear;
+    float pad0;
+    physx_PxVec3_Pod angular;
+    float pad1;
+};
 struct physx_PxArticulationRootLinkData_Pod {
     physx_PxTransform_Pod transform;
     physx_PxVec3_Pod worldLinVel;
@@ -508,14 +514,15 @@ struct physx_PxArticulationCache_Pod {
     float* jointAcceleration;
     float* jointPosition;
     float* jointForce;
-    char structgen_pad0[16];
+    physx_PxSpatialVelocity_Pod* linkVelocity;
+    physx_PxSpatialVelocity_Pod* linkAcceleration;
     physx_PxArticulationRootLinkData_Pod* rootLinkData;
     float* coefficientMatrix;
     float* lambda;
     void* scratchMemory;
     void* scratchAllocator;
     uint32_t version;
-    char structgen_pad1[4];
+    char structgen_pad0[4];
 };
 struct physx_PxArticulationReducedCoordinate_Pod {
     char structgen_pad0[8];
@@ -836,7 +843,7 @@ struct physx_PxPvd_Pod {
     void* vtable_;
 };
 struct physx_PxRigidDynamicLockFlags_Pod {
-    uint16_t mBits;
+    unsigned char mBits;
 };
 struct physx_PxSimulationStatistics_Pod {
     uint32_t nbActiveConstraints;
@@ -1241,7 +1248,7 @@ struct physx_PxBVH33MidphaseDesc_Pod {
 struct physx_PxBVH34MidphaseDesc_Pod {
     uint32_t numPrimsPerLeaf;
 };
-struct Anonymous216_Pod {
+struct Anonymous217_Pod {
     physx_PxBVH33MidphaseDesc_Pod mBVH33Desc;
     physx_PxBVH34MidphaseDesc_Pod mBVH34Desc;
 };
@@ -1589,6 +1596,9 @@ struct physx_PxVehicleTireData_Pod {
 struct physx_PxVehicleWheels4SimData_Pod;
 struct physx_PxVehicleWheelsSimData_Pod {
     char structgen_pad0[96];
+};
+struct physx_PxVehicleWheelsSimFlags_Pod {
+    uint32_t mBits;
 };
 struct physx_PxVehicleWheels4DynData_Pod;
 struct physx_PxVehicleTireForceCalculator_Pod;

--- a/physx-sys/src/physx_generated.hpp
+++ b/physx-sys/src/physx_generated.hpp
@@ -84,6 +84,7 @@ static_assert(sizeof(physx::PxConstraintAllocator) == sizeof(physx_PxConstraintA
 static_assert(sizeof(physx::PxTGSSolverBodyVel) == sizeof(physx_PxTGSSolverBodyVel_Pod), "POD wrapper for physx::PxTGSSolverBodyVel has incorrect size.");
 static_assert(sizeof(physx::PxTGSSolverBodyData) == sizeof(physx_PxTGSSolverBodyData_Pod), "POD wrapper for physx::PxTGSSolverBodyData has incorrect size.");
 static_assert(sizeof(physx::PxSpatialForce) == sizeof(physx_PxSpatialForce_Pod), "POD wrapper for physx::PxSpatialForce has incorrect size.");
+static_assert(sizeof(physx::PxSpatialVelocity) == sizeof(physx_PxSpatialVelocity_Pod), "POD wrapper for physx::PxSpatialVelocity has incorrect size.");
 static_assert(sizeof(physx::PxArticulationRootLinkData) == sizeof(physx_PxArticulationRootLinkData_Pod), "POD wrapper for physx::PxArticulationRootLinkData has incorrect size.");
 static_assert(sizeof(physx::PxArticulationCache) == sizeof(physx_PxArticulationCache_Pod), "POD wrapper for physx::PxArticulationCache has incorrect size.");
 static_assert(sizeof(physx::PxArticulationReducedCoordinate) == sizeof(physx_PxArticulationReducedCoordinate_Pod), "POD wrapper for physx::PxArticulationReducedCoordinate has incorrect size.");
@@ -4670,6 +4671,22 @@ void PxArticulationReducedCoordinate_teleportRootLink_mut(physx_PxArticulationRe
 physx::PxArticulationReducedCoordinate* self_ = reinterpret_cast<physx::PxArticulationReducedCoordinate*>(self__pod);
 physx::PxTransform const& pose = reinterpret_cast<physx::PxTransform const&>(*pose_pod);
 self_->teleportRootLink(pose, autowake);
+}
+
+physx_PxSpatialVelocity_Pod PxArticulationReducedCoordinate_getLinkVelocity_mut(physx_PxArticulationReducedCoordinate_Pod* self__pod, uint32_t linkId) {
+physx::PxArticulationReducedCoordinate* self_ = reinterpret_cast<physx::PxArticulationReducedCoordinate*>(self__pod);
+physx::PxSpatialVelocity returnValue = self_->getLinkVelocity(linkId);
+physx_PxSpatialVelocity_Pod returnValue_pod;
+memcpy(&returnValue_pod, &returnValue, sizeof(returnValue_pod));
+return returnValue_pod;
+}
+
+physx_PxSpatialVelocity_Pod PxArticulationReducedCoordinate_getLinkAcceleration_mut(physx_PxArticulationReducedCoordinate_Pod* self__pod, uint32_t linkId) {
+physx::PxArticulationReducedCoordinate* self_ = reinterpret_cast<physx::PxArticulationReducedCoordinate*>(self__pod);
+physx::PxSpatialVelocity returnValue = self_->getLinkAcceleration(linkId);
+physx_PxSpatialVelocity_Pod returnValue_pod;
+memcpy(&returnValue_pod, &returnValue, sizeof(returnValue_pod));
+return returnValue_pod;
 }
 
 physx_PxArticulationLink_Pod* PxArticulationJointBase_getParentArticulationLink(physx_PxArticulationJointBase_Pod const* self__pod) {
@@ -11709,6 +11726,21 @@ self_->setSubStepCount(thresholdLongitudinalSpeed, lowForwardSpeedSubStepCount, 
 void PxVehicleWheelsSimData_setMinLongSlipDenominator_mut(physx_PxVehicleWheelsSimData_Pod* self__pod, float minLongSlipDenominator) {
 physx::PxVehicleWheelsSimData* self_ = reinterpret_cast<physx::PxVehicleWheelsSimData*>(self__pod);
 self_->setMinLongSlipDenominator(minLongSlipDenominator);
+}
+
+void PxVehicleWheelsSimData_setFlags_mut(physx_PxVehicleWheelsSimData_Pod* self__pod, physx_PxVehicleWheelsSimFlags_Pod flags_pod) {
+physx::PxVehicleWheelsSimData* self_ = reinterpret_cast<physx::PxVehicleWheelsSimData*>(self__pod);
+physx::PxVehicleWheelsSimFlags flags;
+memcpy(&flags, &flags_pod, sizeof(flags));
+self_->setFlags(flags);
+}
+
+physx_PxVehicleWheelsSimFlags_Pod PxVehicleWheelsSimData_getFlags(physx_PxVehicleWheelsSimData_Pod const* self__pod) {
+physx::PxVehicleWheelsSimData const* self_ = reinterpret_cast<physx::PxVehicleWheelsSimData const*>(self__pod);
+physx::PxVehicleWheelsSimFlags returnValue = self_->getFlags();
+physx_PxVehicleWheelsSimFlags_Pod returnValue_pod;
+memcpy(&returnValue_pod, &returnValue, sizeof(returnValue_pod));
+return returnValue_pod;
 }
 
 physx_PxVehicleWheelsSimData_Pod* PxVehicleWheelsSimData_new_alloc(unsigned int anonymous_arg0_pod) {

--- a/physx-sys/src/physx_generated.rs
+++ b/physx-sys/src/physx_generated.rs
@@ -45,17 +45,23 @@ pub const eVELOCITY: Enum = 1u64 as u32;
 pub const eACCELERATION: Enum = 2u64 as u32;
 pub const ePOSITION: Enum = 4u64 as u32;
 pub const eFORCE: Enum = 8u64 as u32;
-pub const eROOT: Enum = 16u64 as u32;
-pub const eALL: Enum = 23u64 as u32;
+pub const eLINKVELOCITY: Enum = 16u64 as u32;
+pub const eLINKACCELERATION: Enum = 32u64 as u32;
+pub const eROOT: Enum = 64u64 as u32;
+pub const eALL: Enum = 119u64 as u32;
 }
 pub mod PxArticulationDriveType{
 pub type Enum = u32;
 pub const eFORCE: Enum = 0u64 as u32;
 pub const eACCELERATION: Enum = 1u64 as u32;
+pub const eTARGET: Enum = 2u64 as u32;
+pub const eVELOCITY: Enum = 3u64 as u32;
+pub const eNONE: Enum = 4u64 as u32;
 }
 pub mod PxArticulationFlag{
 pub type Enum = u32;
 pub const eFIX_BASE: Enum = 1u64 as u32;
+pub const eDRIVE_LIMITS_ARE_FORCES: Enum = 2u64 as u32;
 }
 pub mod PxArticulationJointDriveType{
 pub type Enum = u32;
@@ -866,6 +872,10 @@ pub const eNORM_TIRE_LAT_FORCE: Enum = 9u64 as u32;
 pub const eNORM_TIRE_ALIGNING_MOMENT: Enum = 10u64 as u32;
 pub const eMAX_NB_WHEEL_CHANNELS: Enum = 11u64 as u32;
 }
+pub mod PxVehicleWheelsSimFlag{
+pub type Enum = u32;
+pub const eLIMIT_SUSPENSION_EXPANSION_VELOCITY: Enum = 1u64 as u32;
+}
 pub mod PxVisualizationParameter{
 pub type Enum = u32;
 pub const eSCALE: Enum = 0u64 as u32;
@@ -1222,7 +1232,7 @@ pub struct PxPvd{
 #[derive(Clone, Copy)]
 #[repr(C)]
 pub struct PxRigidDynamicLockFlags{
-    pub mBits: u16,
+    pub mBits: u8,
 }
 #[derive(Clone, Copy)]
 #[repr(C)]
@@ -1377,7 +1387,7 @@ pub struct PxTypedStridedData_physx_PxMaterialTableIndex_{
 }
 #[derive(Clone, Copy)]
 #[repr(C)]
-pub union Anonymous216{
+pub union Anonymous217{
     pub mBVH33Desc: PxBVH33MidphaseDesc,
     pub mBVH34Desc: PxBVH34MidphaseDesc,
 }
@@ -1477,6 +1487,11 @@ pub struct PxFixedSizeLookupTable_eMAX_NB_ENGINE_TORQUE_CURVE_ENTRIES_{
 #[repr(C)]
 pub struct PxVehicleWheels4SimData{
     pxbind_dummy: u8
+}
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct PxVehicleWheelsSimFlags{
+    pub mBits: u32,
 }
 #[derive(Clone, Copy)]
 #[repr(C)]
@@ -2164,6 +2179,8 @@ pub fn PxArticulationReducedCoordinate_getNbLoopJoints(self_: *const PxArticulat
 pub fn PxArticulationReducedCoordinate_getLoopJoints(self_: *const PxArticulationReducedCoordinate, userBuffer: *mut *mut PxJoint, bufferSize: u32, startIndex: u32, ) -> u32;
 pub fn PxArticulationReducedCoordinate_getCoefficientMatrixSize(self_: *const PxArticulationReducedCoordinate, ) -> u32;
 pub fn PxArticulationReducedCoordinate_teleportRootLink_mut(self_: *mut PxArticulationReducedCoordinate, pose: *const PxTransform, autowake: bool, ) -> ();
+pub fn PxArticulationReducedCoordinate_getLinkVelocity_mut(self_: *mut PxArticulationReducedCoordinate, linkId: u32, ) -> PxSpatialVelocity;
+pub fn PxArticulationReducedCoordinate_getLinkAcceleration_mut(self_: *mut PxArticulationReducedCoordinate, linkId: u32, ) -> PxSpatialVelocity;
 pub fn PxArticulationJointBase_getParentArticulationLink(self_: *const PxArticulationJointBase, ) -> *mut PxArticulationLink;
 pub fn PxArticulationJointBase_setParentPose_mut(self_: *mut PxArticulationJointBase, pose: *const PxTransform, ) -> ();
 pub fn PxArticulationJointBase_getParentPose(self_: *const PxArticulationJointBase, ) -> PxTransform;
@@ -3220,6 +3237,8 @@ pub fn PxVehicleWheelsSimData_enableWheel_mut(self_: *mut PxVehicleWheelsSimData
 pub fn PxVehicleWheelsSimData_getIsWheelDisabled(self_: *const PxVehicleWheelsSimData, wheel: u32, ) -> bool;
 pub fn PxVehicleWheelsSimData_setSubStepCount_mut(self_: *mut PxVehicleWheelsSimData, thresholdLongitudinalSpeed: f32, lowForwardSpeedSubStepCount: u32, highForwardSpeedSubStepCount: u32, ) -> ();
 pub fn PxVehicleWheelsSimData_setMinLongSlipDenominator_mut(self_: *mut PxVehicleWheelsSimData, minLongSlipDenominator: f32, ) -> ();
+pub fn PxVehicleWheelsSimData_setFlags_mut(self_: *mut PxVehicleWheelsSimData, flags: PxVehicleWheelsSimFlags, ) -> ();
+pub fn PxVehicleWheelsSimData_getFlags(self_: *const PxVehicleWheelsSimData, ) -> PxVehicleWheelsSimFlags;
 pub fn PxVehicleWheelsSimData_new_alloc(anonymous_arg0: PxEMPTY, ) -> *mut PxVehicleWheelsSimData;
 pub fn PxVehicleWheelsSimData_getBinaryMetaData_mut(stream: *mut PxOutputStream, ) -> ();
 pub fn PxVehicleWheelsSimData_getNbWheels4(self_: *const PxVehicleWheelsSimData, ) -> u32;

--- a/physx-sys/src/structgen/structgen.cpp
+++ b/physx-sys/src/structgen/structgen.cpp
@@ -308,7 +308,7 @@ physx_PxConvexMesh_Pod::dumpLayout(structGen);
 struct physx_PxHullPolygon_Pod: public physx::PxHullPolygon {
     static void dumpLayout(PodStructGen& structGen) {
         structGen.beginStruct("physx_PxHullPolygon_Pod", "PxHullPolygon");
-        structGen.addField("float mPlane[4]", "mPlane", "[f32; 4]",sizeof(physx::PxReal [4]), unsafe_offsetof(physx_PxHullPolygon_Pod, mPlane));
+        structGen.addField("float mPlane[4]", "mPlane", "[f32; 4]",sizeof(physx::PxReal[4]), unsafe_offsetof(physx_PxHullPolygon_Pod, mPlane));
         structGen.addField("uint16_t mNbVerts", "mNbVerts", "u16",sizeof(physx::PxU16), unsafe_offsetof(physx_PxHullPolygon_Pod, mNbVerts));
         structGen.addField("uint16_t mIndexBase", "mIndexBase", "u16",sizeof(physx::PxU16), unsafe_offsetof(physx_PxHullPolygon_Pod, mIndexBase));
         structGen.endStruct(sizeof(physx::PxHullPolygon));
@@ -540,7 +540,7 @@ physx_PxHeightFieldDesc_Pod::dumpLayout(structGen);
 struct physx_PxTriangle_Pod: public physx::PxTriangle {
     static void dumpLayout(PodStructGen& structGen) {
         structGen.beginStruct("physx_PxTriangle_Pod", "PxTriangle");
-        structGen.addField("physx_PxVec3_Pod verts[3]", "verts", "[PxVec3; 3]",sizeof(physx::PxVec3 [3]), unsafe_offsetof(physx_PxTriangle_Pod, verts));
+        structGen.addField("physx_PxVec3_Pod verts[3]", "verts", "[PxVec3; 3]",sizeof(physx::PxVec3[3]), unsafe_offsetof(physx_PxTriangle_Pod, verts));
         structGen.endStruct(sizeof(physx::PxTriangle));
     }
 };
@@ -747,6 +747,18 @@ struct physx_PxSpatialForce_Pod: public physx::PxSpatialForce {
 };
 physx_PxSpatialForce_Pod::dumpLayout(structGen);
 
+struct physx_PxSpatialVelocity_Pod: public physx::PxSpatialVelocity {
+    static void dumpLayout(PodStructGen& structGen) {
+        structGen.beginStruct("physx_PxSpatialVelocity_Pod", "PxSpatialVelocity");
+        structGen.addField("physx_PxVec3_Pod linear", "linear", "PxVec3",sizeof(physx::PxVec3), unsafe_offsetof(physx_PxSpatialVelocity_Pod, linear));
+        structGen.addField("float pad0", "pad0", "f32",sizeof(physx::PxReal), unsafe_offsetof(physx_PxSpatialVelocity_Pod, pad0));
+        structGen.addField("physx_PxVec3_Pod angular", "angular", "PxVec3",sizeof(physx::PxVec3), unsafe_offsetof(physx_PxSpatialVelocity_Pod, angular));
+        structGen.addField("float pad1", "pad1", "f32",sizeof(physx::PxReal), unsafe_offsetof(physx_PxSpatialVelocity_Pod, pad1));
+        structGen.endStruct(sizeof(physx::PxSpatialVelocity));
+    }
+};
+physx_PxSpatialVelocity_Pod::dumpLayout(structGen);
+
 struct physx_PxArticulationRootLinkData_Pod: public physx::PxArticulationRootLinkData {
     static void dumpLayout(PodStructGen& structGen) {
         structGen.beginStruct("physx_PxArticulationRootLinkData_Pod", "PxArticulationRootLinkData");
@@ -770,6 +782,8 @@ struct physx_PxArticulationCache_Pod: public physx::PxArticulationCache {
         structGen.addField("float* jointAcceleration", "jointAcceleration", "*mut f32",sizeof(physx::PxReal *), unsafe_offsetof(physx_PxArticulationCache_Pod, jointAcceleration));
         structGen.addField("float* jointPosition", "jointPosition", "*mut f32",sizeof(physx::PxReal *), unsafe_offsetof(physx_PxArticulationCache_Pod, jointPosition));
         structGen.addField("float* jointForce", "jointForce", "*mut f32",sizeof(physx::PxReal *), unsafe_offsetof(physx_PxArticulationCache_Pod, jointForce));
+        structGen.addField("physx_PxSpatialVelocity_Pod* linkVelocity", "linkVelocity", "*mut PxSpatialVelocity",sizeof(physx::PxSpatialVelocity *), unsafe_offsetof(physx_PxArticulationCache_Pod, linkVelocity));
+        structGen.addField("physx_PxSpatialVelocity_Pod* linkAcceleration", "linkAcceleration", "*mut PxSpatialVelocity",sizeof(physx::PxSpatialVelocity *), unsafe_offsetof(physx_PxArticulationCache_Pod, linkAcceleration));
         structGen.addField("physx_PxArticulationRootLinkData_Pod* rootLinkData", "rootLinkData", "*mut PxArticulationRootLinkData",sizeof(physx::PxArticulationRootLinkData *), unsafe_offsetof(physx_PxArticulationCache_Pod, rootLinkData));
         structGen.addField("float* coefficientMatrix", "coefficientMatrix", "*mut f32",sizeof(physx::PxReal *), unsafe_offsetof(physx_PxArticulationCache_Pod, coefficientMatrix));
         structGen.addField("float* lambda", "lambda", "*mut f32",sizeof(physx::PxReal *), unsafe_offsetof(physx_PxArticulationCache_Pod, lambda));
@@ -1048,7 +1062,7 @@ struct physx_PxContactModifyPair_Pod: public physx::PxContactModifyPair {
         structGen.beginStruct("physx_PxContactModifyPair_Pod", "PxContactModifyPair");
         structGen.addField("physx_PxRigidActor_Pod* actor[2]", "actor", "[*const PxRigidActor; 2]",sizeof(const physx::PxRigidActor *[2]), unsafe_offsetof(physx_PxContactModifyPair_Pod, actor));
         structGen.addField("physx_PxShape_Pod* shape[2]", "shape", "[*const PxShape; 2]",sizeof(const physx::PxShape *[2]), unsafe_offsetof(physx_PxContactModifyPair_Pod, shape));
-        structGen.addField("physx_PxTransform_Pod transform[2]", "transform", "[PxTransform; 2]",sizeof(physx::PxTransform [2]), unsafe_offsetof(physx_PxContactModifyPair_Pod, transform));
+        structGen.addField("physx_PxTransform_Pod transform[2]", "transform", "[PxTransform; 2]",sizeof(physx::PxTransform[2]), unsafe_offsetof(physx_PxContactModifyPair_Pod, transform));
         structGen.addField("physx_PxContactSet_Pod contacts", "contacts", "PxContactSet",sizeof(physx::PxContactSet), unsafe_offsetof(physx_PxContactModifyPair_Pod, contacts));
         structGen.endStruct(sizeof(physx::PxContactModifyPair));
     }
@@ -1179,7 +1193,7 @@ physx_PxPruningStructure_Pod::dumpLayout(structGen);
 
 structGen.passThroughC("struct physx_PxDeletionEventFlags_Pod {\n    unsigned char mBits;\n};\n");
 structGen.passThroughC("struct physx_PxPvd_Pod {\n    void* vtable_;\n};\n");
-structGen.passThroughC("struct physx_PxRigidDynamicLockFlags_Pod {\n    uint16_t mBits;\n};\n");
+structGen.passThroughC("struct physx_PxRigidDynamicLockFlags_Pod {\n    unsigned char mBits;\n};\n");
 struct physx_PxSimulationStatistics_Pod: public physx::PxSimulationStatistics {
     static void dumpLayout(PodStructGen& structGen) {
         structGen.beginStruct("physx_PxSimulationStatistics_Pod", "PxSimulationStatistics");
@@ -1189,7 +1203,7 @@ struct physx_PxSimulationStatistics_Pod: public physx::PxSimulationStatistics {
         structGen.addField("uint32_t nbStaticBodies", "nbStaticBodies", "u32",sizeof(physx::PxU32), unsafe_offsetof(physx_PxSimulationStatistics_Pod, nbStaticBodies));
         structGen.addField("uint32_t nbDynamicBodies", "nbDynamicBodies", "u32",sizeof(physx::PxU32), unsafe_offsetof(physx_PxSimulationStatistics_Pod, nbDynamicBodies));
         structGen.addField("uint32_t nbKinematicBodies", "nbKinematicBodies", "u32",sizeof(physx::PxU32), unsafe_offsetof(physx_PxSimulationStatistics_Pod, nbKinematicBodies));
-        structGen.addField("uint32_t nbShapes[7]", "nbShapes", "[u32; 7]",sizeof(physx::PxU32 [7]), unsafe_offsetof(physx_PxSimulationStatistics_Pod, nbShapes));
+        structGen.addField("uint32_t nbShapes[7]", "nbShapes", "[u32; 7]",sizeof(physx::PxU32[7]), unsafe_offsetof(physx_PxSimulationStatistics_Pod, nbShapes));
         structGen.addField("uint32_t nbAggregates", "nbAggregates", "u32",sizeof(physx::PxU32), unsafe_offsetof(physx_PxSimulationStatistics_Pod, nbAggregates));
         structGen.addField("uint32_t nbArticulations", "nbArticulations", "u32",sizeof(physx::PxU32), unsafe_offsetof(physx_PxSimulationStatistics_Pod, nbArticulations));
         structGen.addField("uint32_t nbAxisSolverConstraints", "nbAxisSolverConstraints", "u32",sizeof(physx::PxU32), unsafe_offsetof(physx_PxSimulationStatistics_Pod, nbAxisSolverConstraints));
@@ -1206,10 +1220,10 @@ struct physx_PxSimulationStatistics_Pod: public physx::PxSimulationStatistics {
         structGen.addField("uint32_t nbPartitions", "nbPartitions", "u32",sizeof(physx::PxU32), unsafe_offsetof(physx_PxSimulationStatistics_Pod, nbPartitions));
         structGen.addField("uint32_t nbBroadPhaseAdds", "nbBroadPhaseAdds", "u32",sizeof(physx::PxU32), unsafe_offsetof(physx_PxSimulationStatistics_Pod, nbBroadPhaseAdds));
         structGen.addField("uint32_t nbBroadPhaseRemoves", "nbBroadPhaseRemoves", "u32",sizeof(physx::PxU32), unsafe_offsetof(physx_PxSimulationStatistics_Pod, nbBroadPhaseRemoves));
-        structGen.addField("uint32_t nbDiscreteContactPairs[7][7]", "nbDiscreteContactPairs", "[[u32; 7]; 7]",sizeof(physx::PxU32 [7][7]), unsafe_offsetof(physx_PxSimulationStatistics_Pod, nbDiscreteContactPairs));
-        structGen.addField("uint32_t nbCCDPairs[7][7]", "nbCCDPairs", "[[u32; 7]; 7]",sizeof(physx::PxU32 [7][7]), unsafe_offsetof(physx_PxSimulationStatistics_Pod, nbCCDPairs));
-        structGen.addField("uint32_t nbModifiedContactPairs[7][7]", "nbModifiedContactPairs", "[[u32; 7]; 7]",sizeof(physx::PxU32 [7][7]), unsafe_offsetof(physx_PxSimulationStatistics_Pod, nbModifiedContactPairs));
-        structGen.addField("uint32_t nbTriggerPairs[7][7]", "nbTriggerPairs", "[[u32; 7]; 7]",sizeof(physx::PxU32 [7][7]), unsafe_offsetof(physx_PxSimulationStatistics_Pod, nbTriggerPairs));
+        structGen.addField("uint32_t nbDiscreteContactPairs[7][7]", "nbDiscreteContactPairs", "[[u32; 7]; 7]",sizeof(physx::PxU32[7][7]), unsafe_offsetof(physx_PxSimulationStatistics_Pod, nbDiscreteContactPairs));
+        structGen.addField("uint32_t nbCCDPairs[7][7]", "nbCCDPairs", "[[u32; 7]; 7]",sizeof(physx::PxU32[7][7]), unsafe_offsetof(physx_PxSimulationStatistics_Pod, nbCCDPairs));
+        structGen.addField("uint32_t nbModifiedContactPairs[7][7]", "nbModifiedContactPairs", "[[u32; 7]; 7]",sizeof(physx::PxU32[7][7]), unsafe_offsetof(physx_PxSimulationStatistics_Pod, nbModifiedContactPairs));
+        structGen.addField("uint32_t nbTriggerPairs[7][7]", "nbTriggerPairs", "[[u32; 7]; 7]",sizeof(physx::PxU32[7][7]), unsafe_offsetof(physx_PxSimulationStatistics_Pod, nbTriggerPairs));
         structGen.endStruct(sizeof(physx::PxSimulationStatistics));
     }
 };
@@ -1248,7 +1262,7 @@ struct physx_PxContactPair_Pod: public physx::PxContactPair {
         structGen.addField("uint16_t contactStreamSize", "contactStreamSize", "u16",sizeof(physx::PxU16), unsafe_offsetof(physx_PxContactPair_Pod, contactStreamSize));
         structGen.addField("physx_PxContactPairFlags_Pod flags", "flags", "PxContactPairFlags",sizeof(physx::PxContactPairFlags), unsafe_offsetof(physx_PxContactPair_Pod, flags));
         structGen.addField("physx_PxPairFlags_Pod events", "events", "PxPairFlags",sizeof(physx::PxPairFlags), unsafe_offsetof(physx_PxContactPair_Pod, events));
-        structGen.addField("uint32_t internalData[2]", "internalData", "[u32; 2]",sizeof(physx::PxU32 [2]), unsafe_offsetof(physx_PxContactPair_Pod, internalData));
+        structGen.addField("uint32_t internalData[2]", "internalData", "[u32; 2]",sizeof(physx::PxU32[2]), unsafe_offsetof(physx_PxContactPair_Pod, internalData));
         structGen.endStruct(sizeof(physx::PxContactPair));
     }
 };
@@ -1334,8 +1348,8 @@ struct physx_PxContactPairVelocity_Pod: public physx::PxContactPairVelocity {
     static void dumpLayout(PodStructGen& structGen) {
         structGen.beginStruct("physx_PxContactPairVelocity_Pod", "PxContactPairVelocity");
         structGen.addField("unsigned char type", "_type", "u8",sizeof(physx::PxU8), unsafe_offsetof(physx_PxContactPairVelocity_Pod, type));
-        structGen.addField("physx_PxVec3_Pod linearVelocity[2]", "linearVelocity", "[PxVec3; 2]",sizeof(physx::PxVec3 [2]), unsafe_offsetof(physx_PxContactPairVelocity_Pod, linearVelocity));
-        structGen.addField("physx_PxVec3_Pod angularVelocity[2]", "angularVelocity", "[PxVec3; 2]",sizeof(physx::PxVec3 [2]), unsafe_offsetof(physx_PxContactPairVelocity_Pod, angularVelocity));
+        structGen.addField("physx_PxVec3_Pod linearVelocity[2]", "linearVelocity", "[PxVec3; 2]",sizeof(physx::PxVec3[2]), unsafe_offsetof(physx_PxContactPairVelocity_Pod, linearVelocity));
+        structGen.addField("physx_PxVec3_Pod angularVelocity[2]", "angularVelocity", "[PxVec3; 2]",sizeof(physx::PxVec3[2]), unsafe_offsetof(physx_PxContactPairVelocity_Pod, angularVelocity));
         structGen.endStruct(sizeof(physx::PxContactPairVelocity));
     }
 };
@@ -1345,7 +1359,7 @@ struct physx_PxContactPairPose_Pod: public physx::PxContactPairPose {
     static void dumpLayout(PodStructGen& structGen) {
         structGen.beginStruct("physx_PxContactPairPose_Pod", "PxContactPairPose");
         structGen.addField("unsigned char type", "_type", "u8",sizeof(physx::PxU8), unsafe_offsetof(physx_PxContactPairPose_Pod, type));
-        structGen.addField("physx_PxTransform_Pod globalPose[2]", "globalPose", "[PxTransform; 2]",sizeof(physx::PxTransform [2]), unsafe_offsetof(physx_PxContactPairPose_Pod, globalPose));
+        structGen.addField("physx_PxTransform_Pod globalPose[2]", "globalPose", "[PxTransform; 2]",sizeof(physx::PxTransform[2]), unsafe_offsetof(physx_PxContactPairPose_Pod, globalPose));
         structGen.endStruct(sizeof(physx::PxContactPairPose));
     }
 };
@@ -1688,7 +1702,7 @@ struct physx_PxBVH34MidphaseDesc_Pod: public physx::PxBVH34MidphaseDesc {
 };
 physx_PxBVH34MidphaseDesc_Pod::dumpLayout(structGen);
 
-structGen.passThroughC("struct Anonymous216_Pod {\n    physx_PxBVH33MidphaseDesc_Pod mBVH33Desc;\n    physx_PxBVH34MidphaseDesc_Pod mBVH34Desc;\n};\n");
+structGen.passThroughC("struct Anonymous217_Pod {\n    physx_PxBVH33MidphaseDesc_Pod mBVH33Desc;\n    physx_PxBVH34MidphaseDesc_Pod mBVH34Desc;\n};\n");
 struct physx_PxMidphaseDesc_Pod: public physx::PxMidphaseDesc {
     static void dumpLayout(PodStructGen& structGen) {
         structGen.beginStruct("physx_PxMidphaseDesc_Pod", "PxMidphaseDesc");
@@ -2099,7 +2113,7 @@ physx_PxVehicleEngineData_Pod::dumpLayout(structGen);
 struct physx_PxVehicleGearsData_Pod: public physx::PxVehicleGearsData {
     static void dumpLayout(PodStructGen& structGen) {
         structGen.beginStruct("physx_PxVehicleGearsData_Pod", "PxVehicleGearsData");
-        structGen.addField("float mRatios[32]", "mRatios", "[f32; 32]",sizeof(physx::PxReal [32]), unsafe_offsetof(physx_PxVehicleGearsData_Pod, mRatios));
+        structGen.addField("float mRatios[32]", "mRatios", "[f32; 32]",sizeof(physx::PxReal[32]), unsafe_offsetof(physx_PxVehicleGearsData_Pod, mRatios));
         structGen.addField("float mFinalRatio", "mFinalRatio", "f32",sizeof(physx::PxReal), unsafe_offsetof(physx_PxVehicleGearsData_Pod, mFinalRatio));
         structGen.addField("uint32_t mNbRatios", "mNbRatios", "u32",sizeof(physx::PxU32), unsafe_offsetof(physx_PxVehicleGearsData_Pod, mNbRatios));
         structGen.addField("float mSwitchTime", "mSwitchTime", "f32",sizeof(physx::PxReal), unsafe_offsetof(physx_PxVehicleGearsData_Pod, mSwitchTime));
@@ -2111,8 +2125,8 @@ physx_PxVehicleGearsData_Pod::dumpLayout(structGen);
 struct physx_PxVehicleAutoBoxData_Pod: public physx::PxVehicleAutoBoxData {
     static void dumpLayout(PodStructGen& structGen) {
         structGen.beginStruct("physx_PxVehicleAutoBoxData_Pod", "PxVehicleAutoBoxData");
-        structGen.addField("float mUpRatios[32]", "mUpRatios", "[f32; 32]",sizeof(physx::PxReal [32]), unsafe_offsetof(physx_PxVehicleAutoBoxData_Pod, mUpRatios));
-        structGen.addField("float mDownRatios[32]", "mDownRatios", "[f32; 32]",sizeof(physx::PxReal [32]), unsafe_offsetof(physx_PxVehicleAutoBoxData_Pod, mDownRatios));
+        structGen.addField("float mUpRatios[32]", "mUpRatios", "[f32; 32]",sizeof(physx::PxReal[32]), unsafe_offsetof(physx_PxVehicleAutoBoxData_Pod, mUpRatios));
+        structGen.addField("float mDownRatios[32]", "mDownRatios", "[f32; 32]",sizeof(physx::PxReal[32]), unsafe_offsetof(physx_PxVehicleAutoBoxData_Pod, mDownRatios));
         structGen.endStruct(sizeof(physx::PxVehicleAutoBoxData));
     }
 };
@@ -2227,7 +2241,7 @@ struct physx_PxVehicleTireData_Pod: public physx::PxVehicleTireData {
         structGen.addField("float mLatStiffY", "mLatStiffY", "f32",sizeof(physx::PxReal), unsafe_offsetof(physx_PxVehicleTireData_Pod, mLatStiffY));
         structGen.addField("float mLongitudinalStiffnessPerUnitGravity", "mLongitudinalStiffnessPerUnitGravity", "f32",sizeof(physx::PxReal), unsafe_offsetof(physx_PxVehicleTireData_Pod, mLongitudinalStiffnessPerUnitGravity));
         structGen.addField("float mCamberStiffnessPerUnitGravity", "mCamberStiffnessPerUnitGravity", "f32",sizeof(physx::PxReal), unsafe_offsetof(physx_PxVehicleTireData_Pod, mCamberStiffnessPerUnitGravity));
-        structGen.addField("float mFrictionVsSlipGraph[3][2]", "mFrictionVsSlipGraph", "[[f32; 2]; 3]",sizeof(physx::PxReal [3][2]), unsafe_offsetof(physx_PxVehicleTireData_Pod, mFrictionVsSlipGraph));
+        structGen.addField("float mFrictionVsSlipGraph[3][2]", "mFrictionVsSlipGraph", "[[f32; 2]; 3]",sizeof(physx::PxReal[3][2]), unsafe_offsetof(physx_PxVehicleTireData_Pod, mFrictionVsSlipGraph));
         structGen.addField("uint32_t mType", "mType", "u32",sizeof(physx::PxU32), unsafe_offsetof(physx_PxVehicleTireData_Pod, mType));
         structGen.endStruct(sizeof(physx::PxVehicleTireData));
     }
@@ -2243,6 +2257,7 @@ struct physx_PxVehicleWheelsSimData_Pod: public physx::PxVehicleWheelsSimData {
 };
 physx_PxVehicleWheelsSimData_Pod::dumpLayout(structGen);
 
+structGen.passThroughC("struct physx_PxVehicleWheelsSimFlags_Pod {\n    uint32_t mBits;\n};\n");
 structGen.passThroughC("struct physx_PxVehicleWheels4DynData_Pod;\n");
 structGen.passThroughC("struct physx_PxVehicleTireForceCalculator_Pod;\n");
 struct physx_PxVehicleWheelsDynData_Pod: public physx::PxVehicleWheelsDynData {
@@ -2262,7 +2277,7 @@ struct physx_PxVehicleWheels_Pod: public physx::PxVehicleWheels {
         structGen.addField("physx_PxVehicleWheelsDynData_Pod mWheelsDynData", "mWheelsDynData", "PxVehicleWheelsDynData",sizeof(physx::PxVehicleWheelsDynData), unsafe_offsetof(physx_PxVehicleWheels_Pod, mWheelsDynData));
         structGen.addField("physx_PxRigidDynamic_Pod* mActor", "mActor", "*mut PxRigidDynamic",sizeof(physx::PxRigidDynamic *), unsafe_offsetof(physx_PxVehicleWheels_Pod, mActor));
         structGen.addField("unsigned char mType", "mType", "u8",sizeof(physx::PxU8), unsafe_offsetof(physx_PxVehicleWheels_Pod, mType));
-        structGen.addField("unsigned char mPad0[14]", "mPad0", "[u8; 14]",sizeof(physx::PxU8 [14]), unsafe_offsetof(physx_PxVehicleWheels_Pod, mPad0));
+        structGen.addField("unsigned char mPad0[14]", "mPad0", "[u8; 14]",sizeof(physx::PxU8[14]), unsafe_offsetof(physx_PxVehicleWheels_Pod, mPad0));
         structGen.endStruct(sizeof(physx::PxVehicleWheels));
     }
 };
@@ -2283,7 +2298,7 @@ physx_PxVehicleDriveSimData_Pod::dumpLayout(structGen);
 struct physx_PxVehicleDriveDynData_Pod: public physx::PxVehicleDriveDynData {
     static void dumpLayout(PodStructGen& structGen) {
         structGen.beginStruct("physx_PxVehicleDriveDynData_Pod", "PxVehicleDriveDynData");
-        structGen.addField("float mControlAnalogVals[16]", "mControlAnalogVals", "[f32; 16]",sizeof(physx::PxReal [16]), unsafe_offsetof(physx_PxVehicleDriveDynData_Pod, mControlAnalogVals));
+        structGen.addField("float mControlAnalogVals[16]", "mControlAnalogVals", "[f32; 16]",sizeof(physx::PxReal[16]), unsafe_offsetof(physx_PxVehicleDriveDynData_Pod, mControlAnalogVals));
         structGen.addField("bool mUseAutoGears", "mUseAutoGears", "bool",sizeof(bool), unsafe_offsetof(physx_PxVehicleDriveDynData_Pod, mUseAutoGears));
         structGen.addField("bool mGearUpPressed", "mGearUpPressed", "bool",sizeof(bool), unsafe_offsetof(physx_PxVehicleDriveDynData_Pod, mGearUpPressed));
         structGen.addField("bool mGearDownPressed", "mGearDownPressed", "bool",sizeof(bool), unsafe_offsetof(physx_PxVehicleDriveDynData_Pod, mGearDownPressed));
@@ -2306,7 +2321,7 @@ struct physx_PxVehicleDrive_Pod: public physx::PxVehicleDrive {
         structGen.addField("physx_PxVehicleWheelsDynData_Pod mWheelsDynData", "mWheelsDynData", "PxVehicleWheelsDynData",sizeof(physx::PxVehicleWheelsDynData), unsafe_offsetof(physx_PxVehicleDrive_Pod, mWheelsDynData));
         structGen.addField("physx_PxRigidDynamic_Pod* mActor", "mActor", "*mut PxRigidDynamic",sizeof(physx::PxRigidDynamic *), unsafe_offsetof(physx_PxVehicleDrive_Pod, mActor));
         structGen.addField("unsigned char mType", "mType", "u8",sizeof(physx::PxU8), unsafe_offsetof(physx_PxVehicleDrive_Pod, mType));
-        structGen.addField("unsigned char mPad0[14]", "mPad0", "[u8; 14]",sizeof(physx::PxU8 [14]), unsafe_offsetof(physx_PxVehicleDrive_Pod, mPad0));
+        structGen.addField("unsigned char mPad0[14]", "mPad0", "[u8; 14]",sizeof(physx::PxU8[14]), unsafe_offsetof(physx_PxVehicleDrive_Pod, mPad0));
         structGen.addField("physx_PxVehicleDriveDynData_Pod mDriveDynData", "mDriveDynData", "PxVehicleDriveDynData",sizeof(physx::PxVehicleDriveDynData), unsafe_offsetof(physx_PxVehicleDrive_Pod, mDriveDynData));
         structGen.endStruct(sizeof(physx::PxVehicleDrive));
     }
@@ -2334,7 +2349,7 @@ struct physx_PxVehicleDrive4W_Pod: public physx::PxVehicleDrive4W {
         structGen.addField("physx_PxVehicleWheelsDynData_Pod mWheelsDynData", "mWheelsDynData", "PxVehicleWheelsDynData",sizeof(physx::PxVehicleWheelsDynData), unsafe_offsetof(physx_PxVehicleDrive4W_Pod, mWheelsDynData));
         structGen.addField("physx_PxRigidDynamic_Pod* mActor", "mActor", "*mut PxRigidDynamic",sizeof(physx::PxRigidDynamic *), unsafe_offsetof(physx_PxVehicleDrive4W_Pod, mActor));
         structGen.addField("unsigned char mType", "mType", "u8",sizeof(physx::PxU8), unsafe_offsetof(physx_PxVehicleDrive4W_Pod, mType));
-        structGen.addField("unsigned char mPad0[14]", "mPad0", "[u8; 14]",sizeof(physx::PxU8 [14]), unsafe_offsetof(physx_PxVehicleDrive4W_Pod, mPad0));
+        structGen.addField("unsigned char mPad0[14]", "mPad0", "[u8; 14]",sizeof(physx::PxU8[14]), unsafe_offsetof(physx_PxVehicleDrive4W_Pod, mPad0));
         structGen.addField("physx_PxVehicleDriveDynData_Pod mDriveDynData", "mDriveDynData", "PxVehicleDriveDynData",sizeof(physx::PxVehicleDriveDynData), unsafe_offsetof(physx_PxVehicleDrive4W_Pod, mDriveDynData));
         structGen.addField("physx_PxVehicleDriveSimData4W_Pod mDriveSimData", "mDriveSimData", "PxVehicleDriveSimData4W",sizeof(physx::PxVehicleDriveSimData4W), unsafe_offsetof(physx_PxVehicleDrive4W_Pod, mDriveSimData));
         structGen.endStruct(sizeof(physx::PxVehicleDrive4W));
@@ -2351,7 +2366,7 @@ struct physx_PxVehicleDriveTank_Pod: public physx::PxVehicleDriveTank {
         structGen.addField("physx_PxVehicleWheelsDynData_Pod mWheelsDynData", "mWheelsDynData", "PxVehicleWheelsDynData",sizeof(physx::PxVehicleWheelsDynData), unsafe_offsetof(physx_PxVehicleDriveTank_Pod, mWheelsDynData));
         structGen.addField("physx_PxRigidDynamic_Pod* mActor", "mActor", "*mut PxRigidDynamic",sizeof(physx::PxRigidDynamic *), unsafe_offsetof(physx_PxVehicleDriveTank_Pod, mActor));
         structGen.addField("unsigned char mType", "mType", "u8",sizeof(physx::PxU8), unsafe_offsetof(physx_PxVehicleDriveTank_Pod, mType));
-        structGen.addField("unsigned char mPad0[14]", "mPad0", "[u8; 14]",sizeof(physx::PxU8 [14]), unsafe_offsetof(physx_PxVehicleDriveTank_Pod, mPad0));
+        structGen.addField("unsigned char mPad0[14]", "mPad0", "[u8; 14]",sizeof(physx::PxU8[14]), unsafe_offsetof(physx_PxVehicleDriveTank_Pod, mPad0));
         structGen.addField("physx_PxVehicleDriveDynData_Pod mDriveDynData", "mDriveDynData", "PxVehicleDriveDynData",sizeof(physx::PxVehicleDriveDynData), unsafe_offsetof(physx_PxVehicleDriveTank_Pod, mDriveDynData));
         structGen.addField("physx_PxVehicleDriveSimData_Pod mDriveSimData", "mDriveSimData", "PxVehicleDriveSimData",sizeof(physx::PxVehicleDriveSimData), unsafe_offsetof(physx_PxVehicleDriveTank_Pod, mDriveSimData));
         structGen.endStruct(sizeof(physx::PxVehicleDriveTank));
@@ -2468,7 +2483,7 @@ struct physx_PxVehicleDriveNW_Pod: public physx::PxVehicleDriveNW {
         structGen.addField("physx_PxVehicleWheelsDynData_Pod mWheelsDynData", "mWheelsDynData", "PxVehicleWheelsDynData",sizeof(physx::PxVehicleWheelsDynData), unsafe_offsetof(physx_PxVehicleDriveNW_Pod, mWheelsDynData));
         structGen.addField("physx_PxRigidDynamic_Pod* mActor", "mActor", "*mut PxRigidDynamic",sizeof(physx::PxRigidDynamic *), unsafe_offsetof(physx_PxVehicleDriveNW_Pod, mActor));
         structGen.addField("unsigned char mType", "mType", "u8",sizeof(physx::PxU8), unsafe_offsetof(physx_PxVehicleDriveNW_Pod, mType));
-        structGen.addField("unsigned char mPad0[14]", "mPad0", "[u8; 14]",sizeof(physx::PxU8 [14]), unsafe_offsetof(physx_PxVehicleDriveNW_Pod, mPad0));
+        structGen.addField("unsigned char mPad0[14]", "mPad0", "[u8; 14]",sizeof(physx::PxU8[14]), unsafe_offsetof(physx_PxVehicleDriveNW_Pod, mPad0));
         structGen.addField("physx_PxVehicleDriveDynData_Pod mDriveDynData", "mDriveDynData", "PxVehicleDriveDynData",sizeof(physx::PxVehicleDriveDynData), unsafe_offsetof(physx_PxVehicleDriveNW_Pod, mDriveDynData));
         structGen.addField("physx_PxVehicleDriveSimDataNW_Pod mDriveSimData", "mDriveSimData", "PxVehicleDriveSimDataNW",sizeof(physx::PxVehicleDriveSimDataNW), unsafe_offsetof(physx_PxVehicleDriveNW_Pod, mDriveSimData));
         structGen.endStruct(sizeof(physx::PxVehicleDriveNW));
@@ -2487,8 +2502,8 @@ physx_PxVehicleDrive4WRawInputData_Pod::dumpLayout(structGen);
 struct physx_PxVehicleKeySmoothingData_Pod: public physx::PxVehicleKeySmoothingData {
     static void dumpLayout(PodStructGen& structGen) {
         structGen.beginStruct("physx_PxVehicleKeySmoothingData_Pod", "PxVehicleKeySmoothingData");
-        structGen.addField("float mRiseRates[16]", "mRiseRates", "[f32; 16]",sizeof(physx::PxReal [16]), unsafe_offsetof(physx_PxVehicleKeySmoothingData_Pod, mRiseRates));
-        structGen.addField("float mFallRates[16]", "mFallRates", "[f32; 16]",sizeof(physx::PxReal [16]), unsafe_offsetof(physx_PxVehicleKeySmoothingData_Pod, mFallRates));
+        structGen.addField("float mRiseRates[16]", "mRiseRates", "[f32; 16]",sizeof(physx::PxReal[16]), unsafe_offsetof(physx_PxVehicleKeySmoothingData_Pod, mRiseRates));
+        structGen.addField("float mFallRates[16]", "mFallRates", "[f32; 16]",sizeof(physx::PxReal[16]), unsafe_offsetof(physx_PxVehicleKeySmoothingData_Pod, mFallRates));
         structGen.endStruct(sizeof(physx::PxVehicleKeySmoothingData));
     }
 };
@@ -2498,8 +2513,8 @@ structGen.passThroughC("struct PxFixedSizeLookupTable_8__Pod {\n    float mDataP
 struct physx_PxVehiclePadSmoothingData_Pod: public physx::PxVehiclePadSmoothingData {
     static void dumpLayout(PodStructGen& structGen) {
         structGen.beginStruct("physx_PxVehiclePadSmoothingData_Pod", "PxVehiclePadSmoothingData");
-        structGen.addField("float mRiseRates[16]", "mRiseRates", "[f32; 16]",sizeof(physx::PxReal [16]), unsafe_offsetof(physx_PxVehiclePadSmoothingData_Pod, mRiseRates));
-        structGen.addField("float mFallRates[16]", "mFallRates", "[f32; 16]",sizeof(physx::PxReal [16]), unsafe_offsetof(physx_PxVehiclePadSmoothingData_Pod, mFallRates));
+        structGen.addField("float mRiseRates[16]", "mRiseRates", "[f32; 16]",sizeof(physx::PxReal[16]), unsafe_offsetof(physx_PxVehiclePadSmoothingData_Pod, mRiseRates));
+        structGen.addField("float mFallRates[16]", "mFallRates", "[f32; 16]",sizeof(physx::PxReal[16]), unsafe_offsetof(physx_PxVehiclePadSmoothingData_Pod, mFallRates));
         structGen.endStruct(sizeof(physx::PxVehiclePadSmoothingData));
     }
 };
@@ -2524,8 +2539,8 @@ physx_PxVehicleDriveTankRawInputData_Pod::dumpLayout(structGen);
 struct physx_PxVehicleCopyDynamicsMap_Pod: public physx::PxVehicleCopyDynamicsMap {
     static void dumpLayout(PodStructGen& structGen) {
         structGen.beginStruct("physx_PxVehicleCopyDynamicsMap_Pod", "PxVehicleCopyDynamicsMap");
-        structGen.addField("unsigned char sourceWheelIds[20]", "sourceWheelIds", "[u8; 20]",sizeof(physx::PxU8 [20]), unsafe_offsetof(physx_PxVehicleCopyDynamicsMap_Pod, sourceWheelIds));
-        structGen.addField("unsigned char targetWheelIds[20]", "targetWheelIds", "[u8; 20]",sizeof(physx::PxU8 [20]), unsafe_offsetof(physx_PxVehicleCopyDynamicsMap_Pod, targetWheelIds));
+        structGen.addField("unsigned char sourceWheelIds[20]", "sourceWheelIds", "[u8; 20]",sizeof(physx::PxU8[20]), unsafe_offsetof(physx_PxVehicleCopyDynamicsMap_Pod, sourceWheelIds));
+        structGen.addField("unsigned char targetWheelIds[20]", "targetWheelIds", "[u8; 20]",sizeof(physx::PxU8[20]), unsafe_offsetof(physx_PxVehicleCopyDynamicsMap_Pod, targetWheelIds));
         structGen.endStruct(sizeof(physx::PxVehicleCopyDynamicsMap));
     }
 };
@@ -2562,7 +2577,7 @@ struct physx_PxVehicleNoDrive_Pod: public physx::PxVehicleNoDrive {
         structGen.addField("physx_PxVehicleWheelsDynData_Pod mWheelsDynData", "mWheelsDynData", "PxVehicleWheelsDynData",sizeof(physx::PxVehicleWheelsDynData), unsafe_offsetof(physx_PxVehicleNoDrive_Pod, mWheelsDynData));
         structGen.addField("physx_PxRigidDynamic_Pod* mActor", "mActor", "*mut PxRigidDynamic",sizeof(physx::PxRigidDynamic *), unsafe_offsetof(physx_PxVehicleNoDrive_Pod, mActor));
         structGen.addField("unsigned char mType", "mType", "u8",sizeof(physx::PxU8), unsafe_offsetof(physx_PxVehicleNoDrive_Pod, mType));
-        structGen.addField("unsigned char mPad0[14]", "mPad0", "[u8; 14]",sizeof(physx::PxU8 [14]), unsafe_offsetof(physx_PxVehicleNoDrive_Pod, mPad0));
+        structGen.addField("unsigned char mPad0[14]", "mPad0", "[u8; 14]",sizeof(physx::PxU8[14]), unsafe_offsetof(physx_PxVehicleNoDrive_Pod, mPad0));
         structGen.endStruct(sizeof(physx::PxVehicleNoDrive));
     }
 };

--- a/physx/src/rigid_dynamic.rs
+++ b/physx/src/rigid_dynamic.rs
@@ -45,9 +45,7 @@ impl PxFlags for RigidDynamicLockFlags {
     type Target = PxRigidDynamicLockFlags;
 
     fn into_px(self) -> Self::Target {
-        PxRigidDynamicLockFlags {
-            mBits: self.bits(),
-        }
+        PxRigidDynamicLockFlags { mBits: self.bits() }
     }
 
     fn from_px(flags: Self::Target) -> Self {

--- a/physx/src/rigid_dynamic.rs
+++ b/physx/src/rigid_dynamic.rs
@@ -46,12 +46,12 @@ impl PxFlags for RigidDynamicLockFlags {
 
     fn into_px(self) -> Self::Target {
         PxRigidDynamicLockFlags {
-            mBits: self.bits() as u16,
+            mBits: self.bits(),
         }
     }
 
     fn from_px(flags: Self::Target) -> Self {
-        unsafe { BitFlags::from_bits_unchecked(flags.mBits as u8) }
+        unsafe { BitFlags::from_bits_unchecked(flags.mBits) }
     }
 }
 


### PR DESCRIPTION
This makes it a bit easier to add new targets since it's possible to use newer clang/llvm libs. Also updated documentation.

However it seems some of the generated bindings got some new types (did they not the currently checked in Physx version?) which causes some problems since I have some trouble re-generating all the platform specific bindings. I can do it for my own platform ofc but would be nice with some help for the rest of the platforms.