### PR TITLE
Add support for setting up the physx error callback

### DIFF
--- a/physx-sys/src/lib.rs
+++ b/physx-sys/src/lib.rs
@@ -354,8 +354,6 @@ pub type ZoneEndCallback = unsafe extern "C" fn(*const c_void, *const i8, bool, 
 pub type ErrorCallback =
     unsafe extern "C" fn(u32, *const c_void, *const c_void, u32, *const c_void);
 
-pub type ErrorUserdataDeleteCallback = unsafe extern "C" fn(*mut c_void);
-
 extern "C" {
     pub fn physx_create_foundation() -> *mut PxFoundation;
     pub fn physx_create_foundation_with_alloc(
@@ -365,7 +363,6 @@ extern "C" {
 
     pub fn get_default_allocator() -> *mut PxDefaultAllocator;
     pub fn get_default_error_callback() -> *mut PxDefaultErrorCallback;
-    pub fn create_default_error_callback() -> *mut PxDefaultErrorCallback;
 
     /// Destroy the returned callback object using PxQueryFilterCallback_delete.
     pub fn create_raycast_filter_callback(
@@ -395,7 +392,6 @@ extern "C" {
     pub fn create_error_callback(
         error_callback: ErrorCallback,
         userdata: *mut c_void,
-        userdata_deleter: ErrorUserdataDeleteCallback,
     ) -> *mut PxErrorCallback;
 
     pub fn destroy_error_callback(error_callback: *mut PxErrorCallback);

--- a/physx-sys/src/lib.rs
+++ b/physx-sys/src/lib.rs
@@ -352,7 +352,7 @@ pub type ZoneStartCallback =
 pub type ZoneEndCallback = unsafe extern "C" fn(*const c_void, *const i8, bool, u64, *const c_void);
 
 pub type ErrorCallback =
-    unsafe extern "C" fn(u32, *const c_void, *const c_void, u32, *const c_void);
+    unsafe extern "C" fn(PxErrorCode::Enum, *const c_void, *const c_void, u32, *const c_void);
 
 extern "C" {
     pub fn physx_create_foundation() -> *mut PxFoundation;

--- a/physx-sys/src/lib.rs
+++ b/physx-sys/src/lib.rs
@@ -354,8 +354,7 @@ pub type ZoneEndCallback = unsafe extern "C" fn(*const c_void, *const i8, bool, 
 pub type ErrorCallback =
     unsafe extern "C" fn(u32, *const c_void, *const c_void, u32, *const c_void);
 
-pub type ErrorUserdataDeleteCallback =
-    unsafe extern "C" fn(*mut c_void);
+pub type ErrorUserdataDeleteCallback = unsafe extern "C" fn(*mut c_void);
 
 extern "C" {
     pub fn physx_create_foundation() -> *mut PxFoundation;
@@ -399,9 +398,7 @@ extern "C" {
         userdata_deleter: ErrorUserdataDeleteCallback,
     ) -> *mut PxErrorCallback;
 
-    pub fn destroy_error_callback(
-        error_callback: *mut PxErrorCallback,
-    );
+    pub fn destroy_error_callback(error_callback: *mut PxErrorCallback);
 
     pub fn get_default_simulation_filter_shader() -> *mut c_void;
 

--- a/physx-sys/src/lib.rs
+++ b/physx-sys/src/lib.rs
@@ -351,6 +351,12 @@ pub type ZoneStartCallback =
 
 pub type ZoneEndCallback = unsafe extern "C" fn(*const c_void, *const i8, bool, u64, *const c_void);
 
+pub type ErrorCallback =
+    unsafe extern "C" fn(u32, *const c_void, *const c_void, u32, *const c_void);
+
+pub type ErrorUserdataDeleteCallback =
+    unsafe extern "C" fn(*mut c_void);
+
 extern "C" {
     pub fn physx_create_foundation() -> *mut PxFoundation;
     pub fn physx_create_foundation_with_alloc(
@@ -360,6 +366,7 @@ extern "C" {
 
     pub fn get_default_allocator() -> *mut PxDefaultAllocator;
     pub fn get_default_error_callback() -> *mut PxDefaultErrorCallback;
+    pub fn create_default_error_callback() -> *mut PxDefaultErrorCallback;
 
     /// Destroy the returned callback object using PxQueryFilterCallback_delete.
     pub fn create_raycast_filter_callback(
@@ -385,6 +392,16 @@ extern "C" {
     ) -> *mut PxProfilerCallback;
 
     pub fn get_alloc_callback_user_data(alloc_callback: *mut PxAllocatorCallback) -> *mut c_void;
+
+    pub fn create_error_callback(
+        error_callback: ErrorCallback,
+        userdata: *mut c_void,
+        userdata_deleter: ErrorUserdataDeleteCallback,
+    ) -> *mut PxErrorCallback;
+
+    pub fn destroy_error_callback(
+        error_callback: *mut PxErrorCallback,
+    );
 
     pub fn get_default_simulation_filter_shader() -> *mut c_void;
 

--- a/physx-sys/src/physx_api.cpp
+++ b/physx-sys/src/physx_api.cpp
@@ -226,6 +226,34 @@ public:
     void *mUserData;
 };
 
+using ErrorCallback = void (*)(PxErrorCode::Enum code, const char* message, const char* file, int line, void* userdata);
+using ErrorUserdataDeleteCallback = void (*)(void* userdata);
+
+class ErrorTrampoline : public PxErrorCallback {
+public:
+    ErrorTrampoline(ErrorCallback errorCb, void* userdata, ErrorUserdataDeleteCallback userdataDeleter)
+        : mErrorCallback(errorCb), mUserdata(userdata), mUserdataDeleteCallback(userdataDeleter) {
+    }
+
+    ~ErrorTrampoline() override {
+        if(mUserdataDeleteCallback) {
+            mUserdataDeleteCallback(mUserdata);
+        }
+    }
+
+    ErrorTrampoline(ErrorTrampoline const&) =delete;
+    ErrorTrampoline& operator=(ErrorTrampoline const&) =delete;
+
+    void reportError(PxErrorCode::Enum code, const char* message, const char* file, int line) override {
+        mErrorCallback(code, message, file, line, mUserdata);
+    }
+
+private:
+    ErrorCallback mErrorCallback = nullptr;
+    ErrorUserdataDeleteCallback mUserdataDeleteCallback = nullptr;
+    void* mUserdata = nullptr;
+};
+
 extern "C"
 {
     PxFoundation *physx_create_foundation()
@@ -245,11 +273,18 @@ extern "C"
         return &gAllocator;
     }
 
+    // TODO (nises): should this be removed?
     // fixme[tolsson]: this might be iffy on Windows with DLLs if we have multiple packages
     // linking against the raw interface
     PxErrorCallback* get_default_error_callback()
     {
         return &gErrorCallback;
+    }
+
+    // like get_default_error_callback but allocates a new callback object
+    PxErrorCallback* create_default_error_callback()
+    {
+        return new PxDefaultErrorCallback{};
     }
 
     PxPhysics *physx_create_physics(PxFoundation *foundation)
@@ -285,6 +320,20 @@ extern "C"
         void *userdata
     ) {
         return new CustomProfilerTrampoline(zone_start_callback, zone_end_callback, userdata);
+    }
+
+    PxErrorCallback *create_error_callback(
+        ErrorCallback error_callback,
+        void* userdata,
+        ErrorUserdataDeleteCallback userdata_deleter
+    ) {
+        return new ErrorTrampoline(error_callback, userdata, userdata_deleter);
+    }
+
+    void destroy_error_callback(
+        PxErrorCallback *error_callback
+    ) {
+        delete error_callback;
     }
 
     void *get_default_simulation_filter_shader()

--- a/physx/src/foundation.rs
+++ b/physx/src/foundation.rs
@@ -95,22 +95,21 @@ pub trait Foundation: Class<physx_sys::PxFoundation> + Sized {
     }
 
     /// Tries to create a PxFoundation with the provided allocator and error callbacks.
-    /// `error_callback` must live as long as the returned `Foundation`
     /// Returns `None` if `phys_PxCreateFoundation` returns a null pointer.
+    /// # Safety
+    /// `error_callback` must live as long as the returned `Foundation`
     unsafe fn with_allocator_error_callback(
         allocator: Self::Allocator,
         error_callback: *mut PxErrorCallback,
     ) -> Option<Owner<Self>> {
-        unsafe {
-            Owner::from_raw(
-                phys_PxCreateFoundation(
-                    crate::physics::PX_PHYSICS_VERSION,
-                    allocator.into_px(),
-                    error_callback,
-                )
-                .cast::<Self>(),
+        Owner::from_raw(
+            phys_PxCreateFoundation(
+                crate::physics::PX_PHYSICS_VERSION,
+                allocator.into_px(),
+                error_callback,
             )
-        }
+            .cast::<Self>(),
+        )
     }
 
     /// Get the error callback.

--- a/physx/src/foundation.rs
+++ b/physx/src/foundation.rs
@@ -20,7 +20,7 @@ use physx_sys::{
 };
 use std::{
     alloc::{alloc, dealloc, Layout},
-    ffi::{c_void, CStr},
+    ffi::{c_void, CStr, c_char},
     marker::PhantomData,
     mem::{align_of, size_of},
     sync::atomic::{AtomicUsize, Ordering::SeqCst},
@@ -324,8 +324,8 @@ unsafe extern "C" fn report_error_helper(
         debug_assert!(false, "bad error code {}", code);
         Default::default()
     });
-    let message = String::from_utf8_lossy(CStr::from_ptr(message.cast::<i8>()).to_bytes());
-    let file = String::from_utf8_lossy(CStr::from_ptr(file.cast::<i8>()).to_bytes());
+    let message = String::from_utf8_lossy(CStr::from_ptr(message.cast::<c_char>()).to_bytes());
+    let file = String::from_utf8_lossy(CStr::from_ptr(file.cast::<c_char>()).to_bytes());
     let ec = &*user_data.cast::<Box<dyn ErrorCallback>>();
     ec.report_error(code, &message, &file, line);
 }

--- a/physx/src/foundation.rs
+++ b/physx/src/foundation.rs
@@ -325,14 +325,11 @@ unsafe extern "C" fn report_error_helper(
         debug_assert!(false, "bad error code {}", code);
         Default::default()
     });
-    let message = unsafe { CStr::from_ptr(message.cast::<i8>()) }
-        .to_str()
-        .unwrap_or("non-utf8 chars in message");
-    let file = unsafe { CStr::from_ptr(file.cast::<i8>()) }
-        .to_str()
-        .unwrap_or("non-utf8 chars in file");
+    let message =
+        String::from_utf8_lossy(unsafe { CStr::from_ptr(message.cast::<i8>()) }.to_bytes());
+    let file = String::from_utf8_lossy(unsafe { CStr::from_ptr(file.cast::<i8>()) }.to_bytes());
     let ec = unsafe { &*user_data.cast::<Box<dyn ErrorCallback>>() };
-    ec.report_error(code, message, file, line);
+    ec.report_error(code, &message, &file, line);
 }
 
 unsafe extern "C" fn error_userdata_drop_helper(user_data: *mut c_void) {

--- a/physx/src/foundation.rs
+++ b/physx/src/foundation.rs
@@ -57,8 +57,7 @@ impl<Allocator: AllocatorCallback> Drop for PxFoundation<Allocator> {
             };
             let error_callback: *mut PxErrorCallback = self
                 .get_error_callback()
-                .map(|x| x as *mut PxErrorCallback)
-                .unwrap_or(std::ptr::null_mut());
+                .map_or(std::ptr::null_mut(), |x| x as *mut PxErrorCallback);
             PxFoundation_release_mut(self.as_mut_ptr());
             if !error_callback.is_null() {
                 destroy_error_callback(error_callback);

--- a/physx/src/foundation.rs
+++ b/physx/src/foundation.rs
@@ -39,8 +39,6 @@ pub enum ErrorCode {
     PerfWarning = 128u32,
 }
 
-pub type ErrorCodeFlags = BitFlags<ErrorCode>;
-
 /// A new type wrapper for PxFoundation.  Parametrized by it's Allocator type.
 #[repr(transparent)]
 pub struct PxFoundation<Allocator: AllocatorCallback> {

--- a/physx/src/foundation.rs
+++ b/physx/src/foundation.rs
@@ -86,18 +86,16 @@ pub trait Foundation: Class<physx_sys::PxFoundation> + Sized {
     /// Returns `None` if `phys_PxCreateFoundation` returns a null pointer.
     fn new(allocator: Self::Allocator) -> Option<Owner<Self>> {
         unsafe {
-            Owner::from_raw(
-                phys_PxCreateFoundation(
-                    crate::physics::PX_PHYSICS_VERSION,
-                    allocator.into_px(),
-                    get_default_error_callback() as *mut PxErrorCallback,
-                )
-                .cast::<Self>(),
-            )
+            Owner::from_raw(phys_PxCreateFoundation(
+                crate::physics::PX_PHYSICS_VERSION,
+                allocator.into_px(),
+                get_default_error_callback() as *mut PxErrorCallback,
+            ) as *mut Self)
         }
     }
 
     /// Tries to create a PxFoundation with the provided allocator and error callbacks.
+    /// `error_callback` must live as long as the returned `Foundation`
     /// Returns `None` if `phys_PxCreateFoundation` returns a null pointer.
     unsafe fn with_allocator_error_callback(
         allocator: Self::Allocator,

--- a/physx/src/physics.rs
+++ b/physx/src/physics.rs
@@ -20,7 +20,7 @@ use crate::{
     bvh_structure::BvhStructure,
     constraint::Constraint,
     convex_mesh::ConvexMesh,
-    foundation::{AllocatorCallback, DefaultAllocator, Foundation, PxFoundation, ErrorCallback},
+    foundation::{AllocatorCallback, DefaultAllocator, ErrorCallback, Foundation, PxFoundation},
     geometry::Geometry,
     height_field::HeightField,
     material::Material,
@@ -147,9 +147,12 @@ impl<Allocator: AllocatorCallback, Geom: Shape> PhysicsFoundation<Allocator, Geo
         }
     }
 
-    pub fn with_allocator_error_callback(allocator: Allocator, error_callback: Box<dyn ErrorCallback>) -> PhysicsFoundation<Allocator, Geom> {
-        let mut foundation =
-            PxFoundation::with_allocator_error_callback(allocator, error_callback).expect("Create Foundation returned a null pointer");
+    pub fn with_allocator_error_callback(
+        allocator: Allocator,
+        error_callback: Box<dyn ErrorCallback>,
+    ) -> PhysicsFoundation<Allocator, Geom> {
+        let mut foundation = PxFoundation::with_allocator_error_callback(allocator, error_callback)
+            .expect("Create Foundation returned a null pointer");
         let physics =
             PxPhysics::new(foundation.as_mut()).expect("Create PxPhysics returned a null pointer.");
         Self {
@@ -158,7 +161,7 @@ impl<Allocator: AllocatorCallback, Geom: Shape> PhysicsFoundation<Allocator, Geo
             pvd: None,
             extensions_loaded: false,
         }
-    }    
+    }
 
     pub fn physics(&self) -> &PxPhysics<Geom> {
         self.physics.as_ref()
@@ -728,10 +731,13 @@ impl<Allocator: AllocatorCallback> PhysicsFoundationBuilder<Allocator> {
     }
 
     /// Set error callback
-    pub fn with_error_callback(&mut self, error_callback: Option<Box<dyn ErrorCallback>>) -> &mut Self {
+    pub fn with_error_callback(
+        &mut self,
+        error_callback: Option<Box<dyn ErrorCallback>>,
+    ) -> &mut Self {
         self.error_callback = error_callback;
         self
-    }    
+    }
 
     /// Build the PhysicsFoundation.
     pub fn build<Geom: Shape>(self) -> Option<PhysicsFoundation<Allocator, Geom>> {

--- a/physx/src/physics.rs
+++ b/physx/src/physics.rs
@@ -148,6 +148,7 @@ impl<Allocator: AllocatorCallback, Geom: Shape> PhysicsFoundation<Allocator, Geo
         }
     }
 
+    /// # Safety
     /// `error_callback` must live as long as the returned value
     pub unsafe fn with_allocator_error_callback(
         allocator: Allocator,
@@ -733,6 +734,7 @@ impl<Allocator: AllocatorCallback> PhysicsFoundationBuilder<Allocator> {
     }
 
     /// Set error callback
+    /// # Safety
     /// `error_callback` must live as long as the object created by `build`
     pub unsafe fn with_error_callback(
         &mut self,

--- a/physx/src/physics.rs
+++ b/physx/src/physics.rs
@@ -148,6 +148,7 @@ impl<Allocator: AllocatorCallback, Geom: Shape> PhysicsFoundation<Allocator, Geo
         }
     }
 
+    /// `error_callback` must live as long as the returned value
     pub unsafe fn with_allocator_error_callback(
         allocator: Allocator,
         error_callback: *mut PxErrorCallback,
@@ -732,6 +733,7 @@ impl<Allocator: AllocatorCallback> PhysicsFoundationBuilder<Allocator> {
     }
 
     /// Set error callback
+    /// `error_callback` must live as long as the object created by `build`
     pub unsafe fn with_error_callback(
         &mut self,
         error_callback: *mut PxErrorCallback,


### PR DESCRIPTION
Oh man. c++/rust ffi is not easy 😓 
I did the stateful error callback in the end. Seemed like the cleanest interface.
Is this an ok way to do it?