### PR TITLE
Trait + early conversion for error callback

### DIFF
--- a/physx-sys/CHANGELOG.md
+++ b/physx-sys/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+
+- add new `create_error_callback` which uses the trampoline pattern to send Physx logging to Rust
+
 ## [0.6.0] - 2022-10-03
 
 - add new `create_profiler_callback` which uses the trampoline pattern to send profiling events to Rust.

--- a/physx-sys/src/lib.rs
+++ b/physx-sys/src/lib.rs
@@ -354,8 +354,6 @@ pub type ZoneEndCallback = unsafe extern "C" fn(*const c_void, *const i8, bool, 
 pub type ErrorCallback =
     unsafe extern "C" fn(u32, *const c_void, *const c_void, u32, *const c_void);
 
-pub type ErrorUserdataDeleteCallback = unsafe extern "C" fn(*mut c_void);
-
 extern "C" {
     pub fn physx_create_foundation() -> *mut PxFoundation;
     pub fn physx_create_foundation_with_alloc(
@@ -365,7 +363,6 @@ extern "C" {
 
     pub fn get_default_allocator() -> *mut PxDefaultAllocator;
     pub fn get_default_error_callback() -> *mut PxDefaultErrorCallback;
-    pub fn create_default_error_callback() -> *mut PxDefaultErrorCallback;
 
     /// Destroy the returned callback object using PxQueryFilterCallback_delete.
     pub fn create_raycast_filter_callback(
@@ -395,7 +392,6 @@ extern "C" {
     pub fn create_error_callback(
         error_callback: ErrorCallback,
         userdata: *mut c_void,
-        userdata_deleter: ErrorUserdataDeleteCallback,
     ) -> *mut PxErrorCallback;
 
     pub fn destroy_error_callback(error_callback: *mut PxErrorCallback);

--- a/physx-sys/src/lib.rs
+++ b/physx-sys/src/lib.rs
@@ -352,7 +352,7 @@ pub type ZoneStartCallback =
 pub type ZoneEndCallback = unsafe extern "C" fn(*const c_void, *const i8, bool, u64, *const c_void);
 
 pub type ErrorCallback =
-    unsafe extern "C" fn(u32, *const c_void, *const c_void, u32, *const c_void);
+    unsafe extern "C" fn(PxErrorCode::Enum, *const c_void, *const c_void, u32, *const c_void);
 
 extern "C" {
     pub fn physx_create_foundation() -> *mut PxFoundation;

--- a/physx-sys/src/lib.rs
+++ b/physx-sys/src/lib.rs
@@ -351,7 +351,8 @@ pub type ZoneStartCallback =
 
 pub type ZoneEndCallback = unsafe extern "C" fn(*const c_void, *const i8, bool, u64, *const c_void);
 
-pub type ErrorCallback = unsafe extern "C" fn(PxErrorCode::Enum, *const i8, *const i8, u32, *const c_void);
+pub type ErrorCallback =
+    unsafe extern "C" fn(PxErrorCode::Enum, *const i8, *const i8, u32, *const c_void);
 
 extern "C" {
     pub fn physx_create_foundation() -> *mut PxFoundation;

--- a/physx-sys/src/lib.rs
+++ b/physx-sys/src/lib.rs
@@ -394,8 +394,6 @@ extern "C" {
         userdata: *mut c_void,
     ) -> *mut PxErrorCallback;
 
-    pub fn destroy_error_callback(error_callback: *mut PxErrorCallback);
-
     pub fn get_default_simulation_filter_shader() -> *mut c_void;
 
     /// Create a C++ proxy callback which will forward contact events to `Callback`.

--- a/physx-sys/src/lib.rs
+++ b/physx-sys/src/lib.rs
@@ -354,8 +354,7 @@ pub type ZoneEndCallback = unsafe extern "C" fn(*const c_void, *const i8, bool, 
 pub type ErrorCallback =
     unsafe extern "C" fn(u32, *const c_void, *const c_void, u32, *const c_void);
 
-pub type ErrorUserdataDeleteCallback =
-    unsafe extern "C" fn(*mut c_void);
+pub type ErrorUserdataDeleteCallback = unsafe extern "C" fn(*mut c_void);
 
 extern "C" {
     pub fn physx_create_foundation() -> *mut PxFoundation;
@@ -399,9 +398,7 @@ extern "C" {
         userdata_deleter: ErrorUserdataDeleteCallback,
     ) -> *mut PxErrorCallback;
 
-    pub fn destroy_error_callback(
-        error_callback: *mut PxErrorCallback,
-    );
+    pub fn destroy_error_callback(error_callback: *mut PxErrorCallback);
 
     pub fn get_default_simulation_filter_shader() -> *mut c_void;
 

--- a/physx-sys/src/lib.rs
+++ b/physx-sys/src/lib.rs
@@ -351,8 +351,7 @@ pub type ZoneStartCallback =
 
 pub type ZoneEndCallback = unsafe extern "C" fn(*const c_void, *const i8, bool, u64, *const c_void);
 
-pub type ErrorCallback =
-    unsafe extern "C" fn(PxErrorCode::Enum, *const c_void, *const c_void, u32, *const c_void);
+pub type ErrorCallback = unsafe extern "C" fn(PxErrorCode::Enum, *const i8, *const i8, u32, *const c_void);
 
 extern "C" {
     pub fn physx_create_foundation() -> *mut PxFoundation;

--- a/physx-sys/src/lib.rs
+++ b/physx-sys/src/lib.rs
@@ -351,6 +351,12 @@ pub type ZoneStartCallback =
 
 pub type ZoneEndCallback = unsafe extern "C" fn(*const c_void, *const i8, bool, u64, *const c_void);
 
+pub type ErrorCallback =
+    unsafe extern "C" fn(u32, *const c_void, *const c_void, u32, *const c_void);
+
+pub type ErrorUserdataDeleteCallback =
+    unsafe extern "C" fn(*mut c_void);
+
 extern "C" {
     pub fn physx_create_foundation() -> *mut PxFoundation;
     pub fn physx_create_foundation_with_alloc(
@@ -360,6 +366,7 @@ extern "C" {
 
     pub fn get_default_allocator() -> *mut PxDefaultAllocator;
     pub fn get_default_error_callback() -> *mut PxDefaultErrorCallback;
+    pub fn create_default_error_callback() -> *mut PxDefaultErrorCallback;
 
     /// Destroy the returned callback object using PxQueryFilterCallback_delete.
     pub fn create_raycast_filter_callback(
@@ -385,6 +392,16 @@ extern "C" {
     ) -> *mut PxProfilerCallback;
 
     pub fn get_alloc_callback_user_data(alloc_callback: *mut PxAllocatorCallback) -> *mut c_void;
+
+    pub fn create_error_callback(
+        error_callback: ErrorCallback,
+        userdata: *mut c_void,
+        userdata_deleter: ErrorUserdataDeleteCallback,
+    ) -> *mut PxErrorCallback;
+
+    pub fn destroy_error_callback(
+        error_callback: *mut PxErrorCallback,
+    );
 
     pub fn get_default_simulation_filter_shader() -> *mut c_void;
 

--- a/physx-sys/src/physx_api.cpp
+++ b/physx-sys/src/physx_api.cpp
@@ -226,6 +226,34 @@ public:
     void *mUserData;
 };
 
+using ErrorCallback = void (*)(PxErrorCode::Enum code, const char* message, const char* file, int line, void* userdata);
+using ErrorUserdataDeleteCallback = void (*)(void* userdata);
+
+class ErrorTrampoline : public PxErrorCallback {
+public:
+    ErrorTrampoline(ErrorCallback errorCb, void* userdata, ErrorUserdataDeleteCallback userdataDeleter)
+        : mErrorCallback(errorCb), mUserdata(userdata), mUserdataDeleteCallback(userdataDeleter) {
+    }
+
+    ~ErrorTrampoline() override {
+        if(mUserdataDeleteCallback) {
+            mUserdataDeleteCallback(mUserdata);
+        }
+    }
+
+    ErrorTrampoline(ErrorTrampoline const&) =delete;
+    ErrorTrampoline& operator=(ErrorTrampoline const&) =delete;
+
+    void reportError(PxErrorCode::Enum code, const char* message, const char* file, int line) override {
+        mErrorCallback(code, message, file, line, mUserdata);
+    }
+
+private:
+    ErrorCallback mErrorCallback = nullptr;
+    ErrorUserdataDeleteCallback mUserdataDeleteCallback = nullptr;
+    void* mUserdata = nullptr;
+};
+
 extern "C"
 {
     PxFoundation *physx_create_foundation()
@@ -245,11 +273,18 @@ extern "C"
         return &gAllocator;
     }
 
+    // TODO (nises): should this be removed?
     // fixme[tolsson]: this might be iffy on Windows with DLLs if we have multiple packages
     // linking against the raw interface
     PxErrorCallback* get_default_error_callback()
     {
         return &gErrorCallback;
+    }
+
+    // like get_default_error_callback but allocates a new callback object
+    PxErrorCallback* create_default_error_callback()
+    {
+        return new PxDefaultErrorCallback{};
     }
 
     PxPhysics *physx_create_physics(PxFoundation *foundation)
@@ -285,6 +320,20 @@ extern "C"
         void *userdata
     ) {
         return new CustomProfilerTrampoline(zone_start_callback, zone_end_callback, userdata);
+    }
+
+    PxErrorCallback *create_error_callback(
+        ErrorCallback error_callback,
+        void* userdata,
+        ErrorUserdataDeleteCallback userdata_deleter
+    ) {
+        return new ErrorTrampoline(error_callback, userdata, userdata_deleter);
+    }
+
+    void destroy_error_callback(
+        PxErrorCallback *error_callback
+    ) {
+        delete error_callback;
     }
 
     void *get_default_simulation_filter_shader()

--- a/physx-sys/src/physx_api.cpp
+++ b/physx-sys/src/physx_api.cpp
@@ -311,12 +311,6 @@ extern "C"
         return new ErrorTrampoline(error_callback, userdata);
     }
 
-    void destroy_error_callback(
-        PxErrorCallback *error_callback
-    ) {
-        delete error_callback;
-    }
-
     void *get_default_simulation_filter_shader()
     {
         return (void *)PxDefaultSimulationFilterShader;

--- a/physx-sys/src/physx_api.cpp
+++ b/physx-sys/src/physx_api.cpp
@@ -226,7 +226,7 @@ public:
     void *mUserData;
 };
 
-using ErrorCallback = void (*)(PxErrorCode::Enum code, const char* message, const char* file, int line, void* userdata);
+using ErrorCallback = void (*)(int code, const char* message, const char* file, int line, void* userdata);
 
 class ErrorTrampoline : public PxErrorCallback {
 public:

--- a/physx/CHANGELOG.md
+++ b/physx/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+
+- Add new `PhysicsFoundationBuilder::with_error_callback` API with corresponding trait. This allows plugging in
+  a Rust-side logging framework to consume PhysX errors.
+
+
 ## [0.14.1] - 2022-10-03
 
 - Fixed a bug where the Pvd host string would get deallocated and fail to connect.

--- a/physx/examples/error_callback.rs
+++ b/physx/examples/error_callback.rs
@@ -1,0 +1,52 @@
+use physx::{physics::PhysicsFoundationBuilder, prelude::*, traits::Class};
+use std::ffi::CString;
+
+type PxMaterial = physx::material::PxMaterial<()>;
+type PxShape = physx::shape::PxShape<(), PxMaterial>;
+
+struct ErrorCallback;
+
+impl physx::physics::ErrorCallback for ErrorCallback {
+    fn report_error(
+        &self,
+        code: enumflags2::BitFlags<physx::foundation::ErrorCode>,
+        message: &str,
+        file: &str,
+        line: u32,
+    ) {
+        eprintln!("[{file:}:{line:}] {code:40}: {message:}");
+    }
+}
+fn main() {
+    // Holds a PxFoundation and a PxPhysics.
+    // Also has an optional Pvd and transport, not enabled by default.
+    // The default allocator is the one provided by PhysX.
+    let mut builder = PhysicsFoundationBuilder::default();
+    builder.with_error_callback(ErrorCallback);
+    let mut physics: PhysicsFoundation<physx::foundation::DefaultAllocator, PxShape> =
+        builder.build().expect("a foundation being built");
+
+    unsafe {
+        let error_callback =
+            physx_sys::PxFoundation_getErrorCallback_mut(physics.foundation_mut().as_mut_ptr());
+        let msg = CString::new("this is just a warning").unwrap();
+        let file = CString::new(file!()).unwrap();
+
+        physx_sys::PxErrorCallback_reportError_mut(
+            error_callback,
+            physx_sys::PxErrorCode::eDEBUG_WARNING,
+            msg.as_ptr(),
+            file.as_ptr(),
+            line!() as _,
+        );
+
+        let msg = CString::new("this is an invalid operation").unwrap();
+        physx_sys::PxErrorCallback_reportError_mut(
+            error_callback,
+            physx_sys::PxErrorCode::eINVALID_OPERATION,
+            msg.as_ptr(),
+            file.as_ptr(),
+            line!() as _,
+        );
+    }
+}

--- a/physx/src/foundation.rs
+++ b/physx/src/foundation.rs
@@ -95,22 +95,21 @@ pub trait Foundation: Class<physx_sys::PxFoundation> + Sized {
     }
 
     /// Tries to create a PxFoundation with the provided allocator and error callbacks.
-    /// `error_callback` must live as long as the returned `Foundation`
     /// Returns `None` if `phys_PxCreateFoundation` returns a null pointer.
+    /// # Safety
+    /// `error_callback` must live as long as the returned `Foundation`
     unsafe fn with_allocator_error_callback(
         allocator: Self::Allocator,
         error_callback: *mut PxErrorCallback,
     ) -> Option<Owner<Self>> {
-        unsafe {
-            Owner::from_raw(
-                phys_PxCreateFoundation(
-                    crate::physics::PX_PHYSICS_VERSION,
-                    allocator.into_px(),
-                    error_callback,
-                )
-                .cast::<Self>(),
+        Owner::from_raw(
+            phys_PxCreateFoundation(
+                crate::physics::PX_PHYSICS_VERSION,
+                allocator.into_px(),
+                error_callback,
             )
-        }
+            .cast::<Self>(),
+        )
     }
 
     /// Get the error callback.

--- a/physx/src/foundation.rs
+++ b/physx/src/foundation.rs
@@ -20,7 +20,7 @@ use physx_sys::{
 };
 use std::{
     alloc::{alloc, dealloc, Layout},
-    ffi::{c_void, CStr},
+    ffi::{c_void, CStr, c_char},
     marker::PhantomData,
     mem::{align_of, size_of},
     sync::atomic::{AtomicUsize, Ordering::SeqCst},
@@ -324,8 +324,8 @@ unsafe extern "C" fn report_error_helper(
         debug_assert!(false, "bad error code {}", code);
         Default::default()
     });
-    let message = String::from_utf8_lossy(CStr::from_ptr(message.cast::<i8>()).to_bytes());
-    let file = String::from_utf8_lossy(CStr::from_ptr(file.cast::<i8>()).to_bytes());
+    let message = String::from_utf8_lossy(CStr::from_ptr(message.cast::<c_char>()).to_bytes());
+    let file = String::from_utf8_lossy(CStr::from_ptr(file.cast::<c_char>()).to_bytes());
     let ec = &*user_data.cast::<Box<dyn ErrorCallback>>();
     ec.report_error(code, &message, &file, line);
 }

--- a/physx/src/foundation.rs
+++ b/physx/src/foundation.rs
@@ -84,11 +84,10 @@ pub trait Foundation: Class<physx_sys::PxFoundation> + Sized {
     /// Returns `None` if `phys_PxCreateFoundation` returns a null pointer.
     fn new(allocator: Self::Allocator) -> Option<Owner<Self>> {
         unsafe {
-            Owner::from_raw(phys_PxCreateFoundation(
-                crate::physics::PX_PHYSICS_VERSION,
-                allocator.into_px(),
+            Self::with_allocator_error_callback(
+                allocator,
                 get_default_error_callback() as *mut PxErrorCallback,
-            ) as *mut Self)
+            )
         }
     }
 

--- a/physx/src/foundation.rs
+++ b/physx/src/foundation.rs
@@ -325,14 +325,11 @@ unsafe extern "C" fn report_error_helper(
         debug_assert!(false, "bad error code {}", code);
         Default::default()
     });
-    let message = unsafe { CStr::from_ptr(message.cast::<i8>()) }
-        .to_str()
-        .unwrap_or("non-utf8 chars in message");
-    let file = unsafe { CStr::from_ptr(file.cast::<i8>()) }
-        .to_str()
-        .unwrap_or("non-utf8 chars in file");
+    let message =
+        String::from_utf8_lossy(unsafe { CStr::from_ptr(message.cast::<i8>()) }.to_bytes());
+    let file = String::from_utf8_lossy(unsafe { CStr::from_ptr(file.cast::<i8>()) }.to_bytes());
     let ec = unsafe { &*user_data.cast::<Box<dyn ErrorCallback>>() };
-    ec.report_error(code, message, file, line);
+    ec.report_error(code, &message, &file, line);
 }
 
 unsafe extern "C" fn error_userdata_drop_helper(user_data: *mut c_void) {

--- a/physx/src/foundation.rs
+++ b/physx/src/foundation.rs
@@ -57,8 +57,7 @@ impl<Allocator: AllocatorCallback> Drop for PxFoundation<Allocator> {
             };
             let error_callback: *mut PxErrorCallback = self
                 .get_error_callback()
-                .map(|x| x as *mut PxErrorCallback)
-                .unwrap_or(std::ptr::null_mut());
+                .map_or(std::ptr::null_mut(), |x| x as *mut PxErrorCallback);
             PxFoundation_release_mut(self.as_mut_ptr());
             if !error_callback.is_null() {
                 destroy_error_callback(error_callback);

--- a/physx/src/foundation.rs
+++ b/physx/src/foundation.rs
@@ -39,8 +39,6 @@ pub enum ErrorCode {
     PerfWarning = 128u32,
 }
 
-pub type ErrorCodeFlags = BitFlags<ErrorCode>;
-
 /// A new type wrapper for PxFoundation.  Parametrized by it's Allocator type.
 #[repr(transparent)]
 pub struct PxFoundation<Allocator: AllocatorCallback> {

--- a/physx/src/foundation.rs
+++ b/physx/src/foundation.rs
@@ -86,18 +86,16 @@ pub trait Foundation: Class<physx_sys::PxFoundation> + Sized {
     /// Returns `None` if `phys_PxCreateFoundation` returns a null pointer.
     fn new(allocator: Self::Allocator) -> Option<Owner<Self>> {
         unsafe {
-            Owner::from_raw(
-                phys_PxCreateFoundation(
-                    crate::physics::PX_PHYSICS_VERSION,
-                    allocator.into_px(),
-                    get_default_error_callback() as *mut PxErrorCallback,
-                )
-                .cast::<Self>(),
-            )
+            Owner::from_raw(phys_PxCreateFoundation(
+                crate::physics::PX_PHYSICS_VERSION,
+                allocator.into_px(),
+                get_default_error_callback() as *mut PxErrorCallback,
+            ) as *mut Self)
         }
     }
 
     /// Tries to create a PxFoundation with the provided allocator and error callbacks.
+    /// `error_callback` must live as long as the returned `Foundation`
     /// Returns `None` if `phys_PxCreateFoundation` returns a null pointer.
     unsafe fn with_allocator_error_callback(
         allocator: Self::Allocator,

--- a/physx/src/physics.rs
+++ b/physx/src/physics.rs
@@ -20,7 +20,7 @@ use crate::{
     bvh_structure::BvhStructure,
     constraint::Constraint,
     convex_mesh::ConvexMesh,
-    foundation::{AllocatorCallback, DefaultAllocator, Foundation, PxFoundation, ErrorCallback},
+    foundation::{AllocatorCallback, DefaultAllocator, ErrorCallback, Foundation, PxFoundation},
     geometry::Geometry,
     height_field::HeightField,
     material::Material,
@@ -147,9 +147,12 @@ impl<Allocator: AllocatorCallback, Geom: Shape> PhysicsFoundation<Allocator, Geo
         }
     }
 
-    pub fn with_allocator_error_callback(allocator: Allocator, error_callback: Box<dyn ErrorCallback>) -> PhysicsFoundation<Allocator, Geom> {
-        let mut foundation =
-            PxFoundation::with_allocator_error_callback(allocator, error_callback).expect("Create Foundation returned a null pointer");
+    pub fn with_allocator_error_callback(
+        allocator: Allocator,
+        error_callback: Box<dyn ErrorCallback>,
+    ) -> PhysicsFoundation<Allocator, Geom> {
+        let mut foundation = PxFoundation::with_allocator_error_callback(allocator, error_callback)
+            .expect("Create Foundation returned a null pointer");
         let physics =
             PxPhysics::new(foundation.as_mut()).expect("Create PxPhysics returned a null pointer.");
         Self {
@@ -158,7 +161,7 @@ impl<Allocator: AllocatorCallback, Geom: Shape> PhysicsFoundation<Allocator, Geo
             pvd: None,
             extensions_loaded: false,
         }
-    }    
+    }
 
     pub fn physics(&self) -> &PxPhysics<Geom> {
         self.physics.as_ref()
@@ -728,10 +731,13 @@ impl<Allocator: AllocatorCallback> PhysicsFoundationBuilder<Allocator> {
     }
 
     /// Set error callback
-    pub fn with_error_callback(&mut self, error_callback: Option<Box<dyn ErrorCallback>>) -> &mut Self {
+    pub fn with_error_callback(
+        &mut self,
+        error_callback: Option<Box<dyn ErrorCallback>>,
+    ) -> &mut Self {
         self.error_callback = error_callback;
         self
-    }    
+    }
 
     /// Build the PhysicsFoundation.
     pub fn build<Geom: Shape>(self) -> Option<PhysicsFoundation<Allocator, Geom>> {

--- a/physx/src/physics.rs
+++ b/physx/src/physics.rs
@@ -148,6 +148,7 @@ impl<Allocator: AllocatorCallback, Geom: Shape> PhysicsFoundation<Allocator, Geo
         }
     }
 
+    /// # Safety
     /// `error_callback` must live as long as the returned value
     pub unsafe fn with_allocator_error_callback(
         allocator: Allocator,
@@ -733,6 +734,7 @@ impl<Allocator: AllocatorCallback> PhysicsFoundationBuilder<Allocator> {
     }
 
     /// Set error callback
+    /// # Safety
     /// `error_callback` must live as long as the object created by `build`
     pub unsafe fn with_error_callback(
         &mut self,

--- a/physx/src/physics.rs
+++ b/physx/src/physics.rs
@@ -735,9 +735,6 @@ impl<Allocator: AllocatorCallback> PhysicsFoundationBuilder<Allocator> {
         self
     }
 
-    /// Set error callback
-    /// # Safety
-    /// `error_callback` must live as long as the object created by `build`
     pub fn with_error_callback<EC: ErrorCallback>(&mut self, error_callback: EC) -> &mut Self {
         self.error_callback = unsafe { Some(error_callback.into_px()) };
         self

--- a/physx/src/physics.rs
+++ b/physx/src/physics.rs
@@ -8,6 +8,7 @@ Wrapper interface for PxPhysics
 
 #![allow(clippy::missing_safety_doc)]
 
+mod error_callback;
 mod profiler;
 
 use crate::{
@@ -96,6 +97,7 @@ use physx_sys::{
     PxTolerancesScale_new,
 };
 
+use self::error_callback::ErrorCallback;
 pub use self::profiler::ProfilerCallback;
 
 pub const PX_PHYSICS_VERSION: u32 = crate::version(4, 1, 1);
@@ -736,11 +738,11 @@ impl<Allocator: AllocatorCallback> PhysicsFoundationBuilder<Allocator> {
     /// Set error callback
     /// # Safety
     /// `error_callback` must live as long as the object created by `build`
-    pub unsafe fn with_error_callback(
+    pub unsafe fn with_error_callback<EC: ErrorCallback>(
         &mut self,
-        error_callback: *mut PxErrorCallback,
+        error_callback: EC,
     ) -> &mut Self {
-        self.error_callback = Some(error_callback);
+        self.error_callback = Some(error_callback.into_px());
         self
     }
 

--- a/physx/src/physics.rs
+++ b/physx/src/physics.rs
@@ -148,6 +148,7 @@ impl<Allocator: AllocatorCallback, Geom: Shape> PhysicsFoundation<Allocator, Geo
         }
     }
 
+    /// `error_callback` must live as long as the returned value
     pub unsafe fn with_allocator_error_callback(
         allocator: Allocator,
         error_callback: *mut PxErrorCallback,
@@ -732,6 +733,7 @@ impl<Allocator: AllocatorCallback> PhysicsFoundationBuilder<Allocator> {
     }
 
     /// Set error callback
+    /// `error_callback` must live as long as the object created by `build`
     pub unsafe fn with_error_callback(
         &mut self,
         error_callback: *mut PxErrorCallback,

--- a/physx/src/physics.rs
+++ b/physx/src/physics.rs
@@ -97,7 +97,7 @@ use physx_sys::{
     PxTolerancesScale_new,
 };
 
-use self::error_callback::ErrorCallback;
+pub use self::error_callback::ErrorCallback;
 pub use self::profiler::ProfilerCallback;
 
 pub const PX_PHYSICS_VERSION: u32 = crate::version(4, 1, 1);
@@ -738,11 +738,8 @@ impl<Allocator: AllocatorCallback> PhysicsFoundationBuilder<Allocator> {
     /// Set error callback
     /// # Safety
     /// `error_callback` must live as long as the object created by `build`
-    pub unsafe fn with_error_callback<EC: ErrorCallback>(
-        &mut self,
-        error_callback: EC,
-    ) -> &mut Self {
-        self.error_callback = Some(error_callback.into_px());
+    pub fn with_error_callback<EC: ErrorCallback>(&mut self, error_callback: EC) -> &mut Self {
+        self.error_callback = unsafe { Some(error_callback.into_px()) };
         self
     }
 

--- a/physx/src/physics/error_callback.rs
+++ b/physx/src/physics/error_callback.rs
@@ -1,0 +1,42 @@
+use std::ffi::{c_void, CStr};
+
+use enumflags2::BitFlags;
+use physx_sys::{create_error_callback, PxErrorCallback};
+
+use crate::foundation::ErrorCode;
+
+pub trait ErrorCallback: Sized {
+    fn report_error(&self, code: BitFlags<ErrorCode>, message: &str, file: &str, line: u32);
+    /// # Safety
+    ///
+    /// Do not override this method.
+    unsafe fn into_px(self) -> *mut PxErrorCallback {
+        unsafe extern "C" fn on_message_shim<L: ErrorCallback>(
+            code: physx_sys::PxErrorCode::Enum,
+            message: *const i8,
+            file: *const i8,
+            line: u32,
+            this: *const c_void,
+        ) {
+            let this = &*this.cast::<L>();
+            let msg = CStr::from_ptr(message.cast());
+            let msg = msg.to_str().unwrap(); // SAFETY: We're dealing with basic char* here, so should always convert cleanly to str.
+
+            let file = CStr::from_ptr(file.cast());
+            let file = file.to_str().unwrap(); // SAFETY: We're dealing with basic char* here, so should always convert cleanly to str.
+
+            let code = if code == -1 {
+                BitFlags::ALL
+            } else {
+                BitFlags::from_bits(code as u32).unwrap_or(ErrorCode::InvalidParameter.into())
+            };
+
+            this.report_error(code, msg, file, line);
+        }
+
+        create_error_callback(
+            on_message_shim::<Self>,
+            Box::into_raw(Box::new(self)) as *mut c_void,
+        )
+    }
+}

--- a/physx/src/physics/error_callback.rs
+++ b/physx/src/physics/error_callback.rs
@@ -28,7 +28,8 @@ pub trait ErrorCallback: Sized {
             let code = if code == -1 {
                 BitFlags::ALL
             } else {
-                BitFlags::from_bits(code as u32).unwrap_or(ErrorCode::InvalidParameter.into())
+                BitFlags::from_bits(code as u32)
+                    .unwrap_or_else(|| ErrorCode::InvalidParameter.into())
             };
 
             this.report_error(code, &msg, &file, line);

--- a/physx/src/physics/error_callback.rs
+++ b/physx/src/physics/error_callback.rs
@@ -20,10 +20,10 @@ pub trait ErrorCallback: Sized {
         ) {
             let this = &*this.cast::<L>();
             let msg = CStr::from_ptr(message.cast());
-            let msg = msg.to_str().unwrap(); // SAFETY: We're dealing with basic char* here, so should always convert cleanly to str.
+            let msg = msg.to_string_lossy();
 
             let file = CStr::from_ptr(file.cast());
-            let file = file.to_str().unwrap(); // SAFETY: We're dealing with basic char* here, so should always convert cleanly to str.
+            let file = file.to_string_lossy();
 
             let code = if code == -1 {
                 BitFlags::ALL
@@ -31,7 +31,7 @@ pub trait ErrorCallback: Sized {
                 BitFlags::from_bits(code as u32).unwrap_or(ErrorCode::InvalidParameter.into())
             };
 
-            this.report_error(code, msg, file, line);
+            this.report_error(code, &msg, &file, line);
         }
 
         create_error_callback(

--- a/physx/src/physics/error_callback.rs
+++ b/physx/src/physics/error_callback.rs
@@ -29,7 +29,7 @@ pub trait ErrorCallback: Sized {
                 BitFlags::ALL
             } else {
                 BitFlags::from_bits(code as u32)
-                    .unwrap_or_else(|| ErrorCode::InvalidParameter.into())
+                    .unwrap_or_else(|_| ErrorCode::InvalidParameter.into())
             };
 
             this.report_error(code, &msg, &file, line);


### PR DESCRIPTION
A slight modification to make it work a bit more like your original proposal; while still keeping the trait pattern we have. Also avoids the sized-ness/boxing issue we've seen before.

Not sure why the char types were *const c_void; we try to keep them as signed chars in the interface as it's most consistent.