### PR TITLE
Update

### DIFF
--- a/physx-sys/CHANGELOG.md
+++ b/physx-sys/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Fixed
+- [PR#176](https://github.com/EmbarkStudios/physx-rs/pull/176) removed warnings as errors when building the C++ code. This is not useful for end users and just results in sadness when eg. using newer compiler versions that introduce new/improved warnings.
+
 ## [0.8.0] - 2022-10-20
 - add new `create_assert_handler` function which uses the trampoline pattern to send asserts to Rust
 

--- a/physx-sys/build.rs
+++ b/physx-sys/build.rs
@@ -339,7 +339,6 @@ fn add_common(ctx: &mut Context) {
             "-ferror-limit=0",
             "-Wall",
             "-Wextra",
-            "-Werror",
             "-Wstrict-aliasing=2",
             "-Wno-everything",
         ]
@@ -348,7 +347,6 @@ fn add_common(ctx: &mut Context) {
             "-std=c++14",
             "-Wall",
             "-Wextra",
-            "-Werror",
             "-Wstrict-aliasing=2",
             "-w",
         ]
@@ -378,7 +376,7 @@ fn add_common(ctx: &mut Context) {
 
         flags.push("/std:c++14");
 
-        flags.extend(["/WX", "/W4", "/GF", "/GS-", "/GR-", "/Gd"].iter());
+        flags.extend(["/W4", "/GF", "/GS-", "/GR-", "/Gd"].iter());
 
         // Disable some warnings
         flags.extend(

--- a/physx/CHANGELOG.md
+++ b/physx/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Fixed
+- [PR#176](https://github.com/EmbarkStudios/physx-rs/pull/176) fixed a clippy lint that triggers in 1.65.0.
+
 ## [0.16.0] - 2022-10-20
 - Add new `PhysicsFoundation::set_assert_handler` API with corresponding trait. This allows plugging in
   a Rust-side handler for assertions.

--- a/physx/src/articulation_cache.rs
+++ b/physx/src/articulation_cache.rs
@@ -269,7 +269,7 @@ impl ArticulationCache {
 
     pub fn set_root_link_data(&mut self, data: ArticulationRootLinkData) {
         unsafe {
-            *(*self.px_articulation_cache.as_mut()).rootLinkData = data.into();
+            *(self.px_articulation_cache.as_mut().rootLinkData) = data.into();
         }
     }
 }


### PR DESCRIPTION
Fixes some bitwise instead of logical warnings, and disables warnings as errors for the C++ code. This is not useful for end users since they don't have direct control of the C++ code, and just results in build failures for new compiler versions.