### PR TITLE
Add scene query support to physx-sys

### DIFF
--- a/physx-sys/CHANGELOG.md
+++ b/physx-sys/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+- [PR#181](https://github.com/EmbarkStudios/physx-rs/pull/181) add raycast, sweep and overlap buffer and callback create and delete methods, and update example to show how to use them for scene raycasting
+
 ### Fixed
 - [PR#182](https://github.com/EmbarkStudios/physx-rs/pull/176) fixed a clippy lint that triggers in 1.66.0.
 

--- a/physx-sys/examples/ball.rs
+++ b/physx-sys/examples/ball.rs
@@ -74,13 +74,12 @@ fn main() {
                     &filter_data,
                     null_mut(),
                     null_mut(),
-                ) {
-                    if (*raycast_buffer).hasBlock {
-                        println!(
-                            "Raycast hit object {}m away",
-                            (*raycast_buffer).block.distance
-                        );
-                    }
+                ) && (*raycast_buffer).hasBlock
+                {
+                    println!(
+                        "Raycast hit object {}m away",
+                        (*raycast_buffer).block.distance
+                    );
                 }
 
                 (pose.p.y) as i32 - 10

--- a/physx-sys/src/lib.rs
+++ b/physx-sys/src/lib.rs
@@ -341,6 +341,15 @@ pub struct FilterShaderCallbackInfo {
 
 pub type SimulationFilterShader = unsafe extern "C" fn(*mut FilterShaderCallbackInfo) -> u16;
 
+pub type RaycastProcessTouchesCallback =
+    unsafe extern "C" fn(*const PxRaycastHit, u32, *mut c_void) -> bool;
+pub type SweepProcessTouchesCallback =
+    unsafe extern "C" fn(*const PxSweepHit, u32, *mut c_void) -> bool;
+pub type OverlapProcessTouchesCallback =
+    unsafe extern "C" fn(*const PxOverlapHit, u32, *mut c_void) -> bool;
+
+pub type FinalizeQueryCallback = unsafe extern "C" fn(*mut c_void);
+
 pub type AllocCallback =
     unsafe extern "C" fn(u64, *const c_void, *const c_void, u32, *const c_void) -> *mut c_void;
 
@@ -376,6 +385,36 @@ extern "C" {
         callback: RaycastHitCallback,
         userdata: *mut c_void,
     ) -> *mut PxQueryFilterCallback;
+
+    pub fn create_raycast_buffer() -> *mut PxRaycastCallback;
+    pub fn create_sweep_buffer() -> *mut PxSweepCallback;
+    pub fn create_overlap_buffer() -> *mut PxOverlapCallback;
+
+    pub fn create_raycast_callback(
+        process_touches_callback: RaycastProcessTouchesCallback,
+        finalize_query_callback: FinalizeQueryCallback,
+        touches_buffer: *mut PxRaycastHit,
+        num_touches: u32,
+        userdata: *mut c_void,
+    ) -> *mut PxRaycastCallback;
+    pub fn create_sweep_callback(
+        process_touches_callback: SweepProcessTouchesCallback,
+        finalize_query_callback: FinalizeQueryCallback,
+        touches_buffer: *mut PxSweepHit,
+        num_touches: u32,
+        userdata: *mut c_void,
+    ) -> *mut PxSweepCallback;
+    pub fn create_overlap_callback(
+        process_touches_callback: OverlapProcessTouchesCallback,
+        finalize_query_callback: FinalizeQueryCallback,
+        touches_buffer: *mut PxOverlapHit,
+        num_touches: u32,
+        userdata: *mut c_void,
+    ) -> *mut PxOverlapCallback;
+
+    pub fn delete_raycast_callback(callback: *mut PxRaycastCallback);
+    pub fn delete_sweep_callback(callback: *mut PxSweepCallback);
+    pub fn delete_overlap_callback(callback: *mut PxOverlapCallback);
 
     pub fn create_alloc_callback(
         alloc_callback: AllocCallback,

--- a/physx-sys/src/physx_api.cpp
+++ b/physx-sys/src/physx_api.cpp
@@ -176,20 +176,113 @@ class RaycastFilterTrampoline : public PxQueryFilterCallback
     }
 };
 
+typedef PxAgain (*RaycastHitProcessTouchesCallback)(const PxRaycastHit *buffer, PxU32 nbHits, void *userdata);
+typedef PxAgain (*SweepHitProcessTouchesCallback)(const PxSweepHit *buffer, PxU32 nbHits, void *userdata);
+typedef PxAgain (*OverlapHitProcessTouchesCallback)(const PxOverlapHit *buffer, PxU32 nbHits, void *userdata);
+typedef void (*HitFinalizeQueryCallback)(void *userdata);
+
+class RaycastHitCallbackTrampoline : public PxRaycastCallback
+{
+  public:
+    RaycastHitCallbackTrampoline(
+        RaycastHitProcessTouchesCallback processTouchesCallback,
+        HitFinalizeQueryCallback finalizeQueryCallback,
+        PxRaycastHit *touchesBuffer,
+        PxU32 numTouches,
+        void *userdata)
+        : PxRaycastCallback(touchesBuffer, numTouches),
+          mProcessTouchesCallback(processTouchesCallback),
+          mFinalizeQueryCallback(finalizeQueryCallback),
+          mUserData(userdata) {}
+
+    RaycastHitProcessTouchesCallback mProcessTouchesCallback;
+    HitFinalizeQueryCallback mFinalizeQueryCallback;
+    void *mUserData;
+
+    PxAgain processTouches(const PxRaycastHit *buffer, PxU32 nbHits) override
+    {
+        return mProcessTouchesCallback(buffer, nbHits, mUserData);
+    }
+
+    void finalizeQuery() override
+    {
+        mFinalizeQueryCallback(mUserData);
+    }
+};
+
+class SweepHitCallbackTrampoline : public PxSweepCallback
+{
+  public:
+    SweepHitCallbackTrampoline(
+        SweepHitProcessTouchesCallback processTouchesCallback,
+        HitFinalizeQueryCallback finalizeQueryCallback,
+        PxSweepHit *touchesBuffer,
+        PxU32 numTouches,
+        void *userdata)
+        : PxSweepCallback(touchesBuffer, numTouches),
+          mProcessTouchesCallback(processTouchesCallback),
+          mFinalizeQueryCallback(finalizeQueryCallback),
+          mUserData(userdata) {}
+
+    SweepHitProcessTouchesCallback mProcessTouchesCallback;
+    HitFinalizeQueryCallback mFinalizeQueryCallback;
+    void *mUserData;
+
+    PxAgain processTouches(const PxSweepHit *buffer, PxU32 nbHits) override
+    {
+        return mProcessTouchesCallback(buffer, nbHits, mUserData);
+    }
+
+    void finalizeQuery() override
+    {
+        mFinalizeQueryCallback(mUserData);
+    }
+};
+
+class OverlapHitCallbackTrampoline : public PxOverlapCallback
+{
+  public:
+    OverlapHitCallbackTrampoline(
+        OverlapHitProcessTouchesCallback processTouchesCallback,
+        HitFinalizeQueryCallback finalizeQueryCallback,
+        PxOverlapHit *touchesBuffer,
+        PxU32 numTouches,
+        void *userdata)
+        : PxOverlapCallback(touchesBuffer, numTouches),
+          mProcessTouchesCallback(processTouchesCallback),
+          mFinalizeQueryCallback(finalizeQueryCallback),
+          mUserData(userdata) {}
+
+    OverlapHitProcessTouchesCallback mProcessTouchesCallback;
+    HitFinalizeQueryCallback mFinalizeQueryCallback;
+    void *mUserData;
+
+    PxAgain processTouches(const PxOverlapHit *buffer, PxU32 nbHits) override
+    {
+        return mProcessTouchesCallback(buffer, nbHits, mUserData);
+    }
+
+    void finalizeQuery() override
+    {
+        mFinalizeQueryCallback(mUserData);
+    }
+};
+
 typedef void * (*AllocCallback)(uint64_t size, const char *typeName, const char *filename, int line, void *userdata);
 typedef void (*DeallocCallback)(void *ptr, void *userdata);
 
 class CustomAllocatorTrampoline : public PxAllocatorCallback {
 public:
     CustomAllocatorTrampoline(AllocCallback allocCb, DeallocCallback deallocCb, void *userdata)
-        : mAllocCallback(allocCb), mDeallocCallback(deallocCb), mUserData(userdata) {
-    }
+        : mAllocCallback(allocCb), mDeallocCallback(deallocCb), mUserData(userdata) {}
 
-	void *allocate(size_t size, const char* typeName, const char* filename, int line) {
+    void *allocate(size_t size, const char *typeName, const char *filename, int line)
+    {
         return mAllocCallback((uint64_t)size, typeName, filename, line, mUserData);
     }
 
-	virtual void deallocate(void* ptr) {
+    virtual void deallocate(void* ptr)
+    {
         mDeallocCallback(ptr, mUserData);
     }
 
@@ -296,8 +389,74 @@ extern "C"
         return new RaycastFilterCallback(actor_to_ignore);
     }
 
-    PxQueryFilterCallback *create_raycast_filter_callback_func(RaycastHitCallback callback, void *userData) {
+    PxQueryFilterCallback *create_raycast_filter_callback_func(RaycastHitCallback callback, void *userData)
+    {
         return new RaycastFilterTrampoline(callback, userData);
+    }
+
+    PxRaycastCallback *create_raycast_buffer()
+    {
+        return new PxRaycastBuffer;
+    }
+
+    PxSweepCallback *create_sweep_buffer()
+    {
+        return new PxSweepBuffer;
+    }
+
+    PxOverlapCallback *create_overlap_buffer()
+    {
+        return new PxOverlapBuffer;
+    }
+
+    PxRaycastCallback *create_raycast_callback(
+        RaycastHitProcessTouchesCallback process_touches_callback,
+        HitFinalizeQueryCallback finalize_query_callback,
+        PxRaycastHit *touchesBuffer,
+        PxU32 numTouches,
+        void *userdata
+    ) {
+        return new RaycastHitCallbackTrampoline(
+            process_touches_callback, finalize_query_callback, touchesBuffer, numTouches, userdata);
+    }
+
+    void delete_raycast_callback(PxRaycastCallback *callback)
+    {
+        delete callback;
+    }
+
+    void delete_sweep_callback(PxSweepCallback *callback)
+    {
+        delete callback;
+    }
+
+    void delete_overlap_callback(PxOverlapCallback *callback)
+    {
+        delete callback;
+    }
+
+    PxSweepCallback *create_sweep_callback(
+        SweepHitProcessTouchesCallback process_touches_callback,
+        HitFinalizeQueryCallback finalize_query_callback,
+        PxSweepHit *touchesBuffer,
+        PxU32 numTouches,
+        void *userdata
+    ) {
+        return new SweepHitCallbackTrampoline(
+            process_touches_callback, finalize_query_callback, touchesBuffer, numTouches, userdata
+        );
+    }
+
+    PxOverlapCallback *create_overlap_callback(
+        OverlapHitProcessTouchesCallback process_touches_callback,
+        HitFinalizeQueryCallback finalize_query_callback,
+        PxOverlapHit *touchesBuffer,
+        PxU32 numTouches,
+        void *userdata
+    ) {
+        return new OverlapHitCallbackTrampoline(
+            process_touches_callback, finalize_query_callback, touchesBuffer, numTouches, userdata
+        );
     }
 
     PxAllocatorCallback *create_alloc_callback(


### PR DESCRIPTION
This just lifts the physx-sys part of #119, so that even if it's not exposed in physx-rs it can at least be accessed through the low-level api.