### PR TITLE
Add support for post filter

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -22,6 +22,12 @@ skip = []
 skip-tree = [
     # window-sys duplicates, only used by pxbind, doesn't affect physx-sys/physx itself
     { name = "windows-sys" },
+
+
+    # rustix duplicates, 
+    # latest tempfile uses rustix v0.37.23, while latest env_logger v0.10.0 uses 0.38.3 
+    # only used by pxbind
+    { name = "rustix" },
 ]
 
 [licenses]

--- a/physx-sys/CHANGELOG.md
+++ b/physx-sys/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+- [PR#201](https://github.com/EmbarkStudios/physx-rs/pull/201) Added `create_pre_and_post_raycast_filter_callback_func`, allowing custom pre and post filtering of query hits.
+
 ## [0.11.1] - 2023-04-18
 ### Fixed
 - [PR#193](https://github.com/EmbarkStudios/physx-rs/pull/193) fixed an issue where `physx-sys` would be needlessly recompiled due to an incorrect filepath.

--- a/physx-sys/pxbind/Cargo.toml
+++ b/physx-sys/pxbind/Cargo.toml
@@ -16,4 +16,4 @@ serde_json = "1.0"
 
 [dev-dependencies]
 insta = "1.26"
-tempfile = "3.3"
+tempfile = "3.6"

--- a/physx-sys/src/lib.rs
+++ b/physx-sys/src/lib.rs
@@ -247,11 +247,8 @@ pub type RaycastHitCallback = unsafe extern "C" fn(
     *const c_void,
 ) -> PxQueryHitType;
 
-pub type PostFilterCallback = unsafe extern "C" fn(
-    *const PxFilterData,
-    *const PxQueryHit,
-    *const c_void,
-) -> PxQueryHitType;
+pub type PostFilterCallback =
+    unsafe extern "C" fn(*const PxFilterData, *const PxQueryHit, *const c_void) -> PxQueryHitType;
 
 #[repr(C)]
 pub struct FilterShaderCallbackInfo {
@@ -314,9 +311,9 @@ extern "C" {
 
     /// Destroy the returned callback object using PxQueryFilterCallback_delete.
     pub fn create_pre_and_post_raycast_filter_callback_func(
-         preFilter: RaycastHitCallback, 
-         postFilter: PostFilterCallback,
-         userdata: *mut c_void
+        preFilter: RaycastHitCallback,
+        postFilter: PostFilterCallback,
+        userdata: *mut c_void,
     ) -> *mut PxQueryFilterCallback;
 
     pub fn create_raycast_buffer() -> *mut PxRaycastCallback;

--- a/physx-sys/src/lib.rs
+++ b/physx-sys/src/lib.rs
@@ -239,14 +239,17 @@ impl Default for SimulationEventCallbackInfo {
     }
 }
 
-/// return 0 = `PxQueryHitType::eNONE`
-/// return 1 = `PxQueryHitType::eTOUCH`
-/// return 2 = `PxQueryHitType::eBLOCK`
 pub type RaycastHitCallback = unsafe extern "C" fn(
     *const PxRigidActor,
     *const PxFilterData,
     *const PxShape,
     hit_flags: u32,
+    *const c_void,
+) -> PxQueryHitType;
+
+pub type PostFilterCallback = unsafe extern "C" fn(
+    *const PxFilterData,
+    *const PxQueryHit,
     *const c_void,
 ) -> PxQueryHitType;
 
@@ -307,6 +310,13 @@ extern "C" {
     pub fn create_raycast_filter_callback_func(
         callback: RaycastHitCallback,
         userdata: *mut c_void,
+    ) -> *mut PxQueryFilterCallback;
+
+    /// Destroy the returned callback object using PxQueryFilterCallback_delete.
+    pub fn create_pre_and_post_raycast_filter_callback_func(
+         preFilter: RaycastHitCallback, 
+         postFilter: PostFilterCallback,
+         userdata: *mut c_void
     ) -> *mut PxQueryFilterCallback;
 
     pub fn create_raycast_buffer() -> *mut PxRaycastCallback;

--- a/physx-sys/src/physx_api.cpp
+++ b/physx-sys/src/physx_api.cpp
@@ -149,6 +149,7 @@ class RaycastFilterCallback : public PxQueryFilterCallback
     }
 };
 
+// TODO: Shouldn't we rename this to PreFilterCallback?
 typedef uint32_t (*RaycastHitCallback)(const PxRigidActor *actor, const PxFilterData *filterData, const PxShape *shape, uint32_t hitFlags, const void *userData);
 typedef uint32_t (*PostFilterCallback)(const PxFilterData *filterData, const PxQueryHit* hit, const void *userData);
 
@@ -423,9 +424,9 @@ extern "C"
         return new RaycastFilterTrampoline(callback, userData);
     }
 
-    PxQueryFilterCallback *create_pre_and_post_raycast_filter_callback_func(RaycastHitCallback callback, void *userData)
+    PxQueryFilterCallback *create_pre_and_post_raycast_filter_callback_func(RaycastHitCallback preFilter, PostFilterCallback postFilter, void *userData)
     {
-        return new RaycastFilterTrampoline(callback, userData);
+        return new RaycastFilterPrePostTrampoline(preFilter, postFilter, userData);
     }
 
     PxRaycastCallback *create_raycast_buffer()


### PR DESCRIPTION
Implements a C++ trampoline and Rust interface for setting both pre and post filters.