### PR TITLE
Release `physx-sys` 0.11.3

### DIFF
--- a/physx-sys/CHANGELOG.md
+++ b/physx-sys/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Fixed
+- 0.11.2 release was broken (wrong case in path names).
+
 ## [0.11.2] - 2023-07-07
 - [PR#201](https://github.com/EmbarkStudios/physx-rs/pull/201) Added `create_pre_and_post_raycast_filter_callback_func`, allowing custom pre and post filtering of query hits.
 

--- a/physx-sys/CHANGELOG.md
+++ b/physx-sys/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+## [0.11.3] - 2023-07-07
 ### Fixed
 - 0.11.2 release was broken (wrong case in path names).
 
@@ -190,7 +191,8 @@
 - Ability to not run the default filter shader before the callback.
 
 <!-- next-url -->
-[Unreleased]: https://github.com/EmbarkStudios/physx-rs/compare/physx-sys-v0.11.2...HEAD
+[Unreleased]: https://github.com/EmbarkStudios/physx-rs/compare/physx-sys-v0.11.3...HEAD
+[0.11.3]: https://github.com/EmbarkStudios/physx-rs/compare/physx-sys-v0.11.2...physx-sys-v0.11.3
 [0.11.2]: https://github.com/EmbarkStudios/physx-rs/compare/physx-sys-v0.11.1...physx-sys-v0.11.2
 [0.11.1]: https://github.com/EmbarkStudios/physx-rs/compare/physx-sys-v0.11.0...physx-sys-v0.11.1
 [0.11.0]: https://github.com/EmbarkStudios/physx-rs/compare/physx-sys-v0.10.0...physx-sys-v0.11.0

--- a/physx-sys/Cargo.toml
+++ b/physx-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "physx-sys"
 description = "Unsafe bindings for NVIDIA PhysX C++ SDK"
-version = "0.11.2"
+version = "0.11.3"
 authors = [
     "Embark <opensource@embark-studios.com>",
     "Tomasz Stachowiak <h3@h3.gd>",

--- a/physx/Cargo.toml
+++ b/physx/Cargo.toml
@@ -23,7 +23,7 @@ structgen = ["physx-sys/structgen"]
 debug-structs = ["physx-sys/debug-structs"]
 
 [dependencies]
-physx-sys = { version = "0.11.2", path = "../physx-sys" }
+physx-sys = { version = "0.11.3", path = "../physx-sys" }
 
 bitflags = "1.3"
 log = "0.4"


### PR DESCRIPTION
Here we go again. 0.11.2 was broken on `crates.io`, most likely due to my repo being broken.