### PR TITLE
Build for x86_64-linux-android with generated/unix/ code

### DIFF
--- a/physx-sys/CHANGELOG.md
+++ b/physx-sys/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Added
+- [PR#209](https://github.com/EmbarkStudios/physx-rs/pull/209) Add support for `x86_64-linux-android`
+
 ## [0.11.3] - 2023-07-07
 ### Fixed
 - 0.11.2 release was broken (wrong case in path names).

--- a/physx-sys/src/lib.rs
+++ b/physx-sys/src/lib.rs
@@ -154,6 +154,13 @@ include!("generated/unix/structgen.rs");
 #[cfg(all(
     not(feature = "structgen"),
     target_os = "android",
+    target_arch = "x86_64",
+))]
+include!("generated/unix/structgen.rs");
+
+#[cfg(all(
+    not(feature = "structgen"),
+    target_os = "android",
     target_arch = "aarch64",
 ))]
 include!("generated/unix/structgen.rs");


### PR DESCRIPTION
This enables building for `x86_64-linux-android` targets, which is particularly useful for running under an Android emulator.

For reference here I first explicitly ran `structgen` (built for x86_64-linux-android to with the latest r25 Android NDK toolchain) on an Android emulator and compared the output to the existing `generated/unix/` code, which was identical.

This was how I double checked the output of structgen cross-compiled for x86_64-android-linux on an Android emulator:

```bash
export ANDROID_API_LEVEL=31
export ANDROID_ARCH=x86_64 # | i686
export ANDROID_ABI=x86_64 # | x86
export HOST_OS=linux # | windows
export EXT="" # | .bat

"$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/$HOST_OS-x86_64/bin/clang++" \
    -DANDROID \
    --target=$ANDROID_ARCH-linux-android$ANDROID_API_LEVEL \
    -std=c++14 \
    -DNDEBUG \
    -DPX_PHYSX_STATIC_LIB \
    -static \
    "-I" "physx/physx/include" \
    "-I" "physx/pxshared/include" \
    "-I" "physx/physx/source/foundation/include" \
    "-o" "./structgen" "src/structgen/structgen.cpp"

# Install emulator via Android SDK
$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager$EXT --update
$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager$EXT "system-images;android-$ANDROID_API_LEVEL;default;$ANDROID_ABI"
$ANDROID_HOME/cmdline-tools/latest/bin/avdmanager$EXT create avd -n pixel_4_$ANDROID_ABI -k "system-images;android-$ANDROID_API_LEVEL;default;$ANDROID_ABI" -d pixel_4

$ANDROID_HOME/emulator/emulator -avd pixel_4_$ANDROID_ABI -no-window

adb push ./structgen /data/local/tmp/structgen
adb shell "cd /data/local/tmp && ./structgen"
adb pull /data/local/tmp/{structgen_out.hpp,structgen_out.rs} .
```