### PR TITLE
Fix misaligned pointer dereference when storing UserData

### DIFF
--- a/physx-sys/pxbind/src/consumer.rs
+++ b/physx-sys/pxbind/src/consumer.rs
@@ -299,7 +299,9 @@ impl<'ast> AstConsumer<'ast> {
                     // If a record decl doesn't have any inner nodes, it's just
                     // a foreward declaration and we can skip it
                     if inn.inner.is_empty() || rec.definition_data.is_none() {
-                        let Some(name) = rec.name.as_deref() else { continue; };
+                        let Some(name) = rec.name.as_deref() else {
+                            continue;
+                        };
 
                         if !self.classes.contains_key(name) {
                             self.recs

--- a/physx-sys/pxbind/src/consumer/enums.rs
+++ b/physx-sys/pxbind/src/consumer/enums.rs
@@ -182,7 +182,9 @@ impl<'ast> super::AstConsumer<'ast> {
         // PhysX uses a PxFlags<> template typedef to create a bitfield type for
         // a specific enum, we use this typedef to also generate an appropriate
         // bitflags that can be transparently passed between the FFI boundary
-        let Some(flags) = super::no_physx(&td.kind.qual_type).strip_prefix("PxFlags<") else { return Ok(()) };
+        let Some(flags) = super::no_physx(&td.kind.qual_type).strip_prefix("PxFlags<") else {
+            return Ok(());
+        };
         // Get rid of `>`
         let flags = &flags[..flags.len() - 1];
 

--- a/physx-sys/pxbind/src/consumer/record.rs
+++ b/physx-sys/pxbind/src/consumer/record.rs
@@ -58,7 +58,9 @@ impl Constructor {
             }
         });
 
-        let Some(first) = iter.next() else { return false };
+        let Some(first) = iter.next() else {
+            return false;
+        };
 
         if first.ends_with(" &&") {
             return true;
@@ -443,7 +445,9 @@ impl<'ast> super::AstConsumer<'ast> {
             return Ok(());
         }
 
-        let Some(rname) = rec.name.as_deref() else { return Ok(()) };
+        let Some(rname) = rec.name.as_deref() else {
+            return Ok(());
+        };
 
         anyhow::ensure!(
             rec.definition_data.is_some(),
@@ -674,7 +678,9 @@ impl<'ast> super::AstConsumer<'ast> {
         template_types: &[(&str, &super::TemplateArg<'ast>)],
         fields: &mut Vec<FieldBinding<'ast>>,
     ) -> anyhow::Result<()> {
-        let Some(rname) = rec.name.as_deref() else { return Ok(()) };
+        let Some(rname) = rec.name.as_deref() else {
+            return Ok(());
+        };
         let mut is_public = !matches!(rec.tag_used, Some(Tag::Class));
 
         for inn in &node.inner {

--- a/physx/CHANGELOG.md
+++ b/physx/CHANGELOG.md
@@ -12,6 +12,9 @@ into mutable and immutable variants.
   - `ActorMap::as_rigid_static` -> `ActorMap::as_rigid_static_mut`
   - `ActorMap::as_articulation_link` -> `ActorMap::as_articulation_link_mut`
 
+### Fixed
+- [PR#211](https://github.com/EmbarkStudios/physx-rs/pull/211) fixed misaligned pointer dereference when using `UserData` with small-size values.
+
 ## [0.18.0] - 2023-03-03
 ### Changed
 - [PR#191](https://github.com/EmbarkStudios/physx-rs/pull/191) replaced `PxCooking` with regular functions as `PxCooking` is deprecated in the C++ code.


### PR DESCRIPTION
see discussion in https://github.com/EmbarkStudios/physx-rs/issues/210

I've also added a test, which verifies userdata storing/retrieving with various types, and may also reproduce a problem with older code. You can run it with the following command:

```sh
cargo test --package physx --lib -- traits::user_data::tests --nocapture
```

line 28 is where the bug is at, lines 24-25 are changed only for consistency reasons