### PR TITLE
Use -fno-strict-aliasing when building physx

### DIFF
--- a/physx-sys/CHANGELOG.md
+++ b/physx-sys/CHANGELOG.md
@@ -5,6 +5,7 @@
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 ### Added
+- [PR#212](https://github.com/EmbarkStudios/physx-rs/pull/212) Build physx with -fno-strict-aliasing.
 - [PR#209](https://github.com/EmbarkStudios/physx-rs/pull/209) Add support for `x86_64-linux-android`
 
 ## [0.11.3] - 2023-07-07

--- a/physx-sys/build.rs
+++ b/physx-sys/build.rs
@@ -346,6 +346,8 @@ fn add_common(ctx: &mut Context) {
             "-std=c++14",
             // Disable all warnings
             "-w",
+            // Many reinterpret_cast tricks in physx break down if we do not disable strict-aliasing
+            "-fno-strict-aliasing",
         ]
     } else if builder.get_compiler().is_like_msvc() {
         // Disable defaults since we disagree with cc in some cases, this


### PR DESCRIPTION
A lot of undefined behavior with all the reinterpret_cast usage in physx.

The following was broken compiling without `-fno-strict-aliasing` with clang/llvm 16:
https://github.com/NVIDIA-Omniverse/PhysX/blob/main/physx/source/geomutils/src/intersection/GuIntersectionRayBox.cpp#L199
