### PR TITLE
Do not manually free materials for shapes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
+resolver = "2"
 members = ["physx", "physx-sys", "physx-sys/pxbind"]

--- a/physx/src/material.rs
+++ b/physx/src/material.rs
@@ -140,7 +140,7 @@ pub trait Material: Class<physx_sys::PxMaterial> + UserData {
     }
 
     /// Set the restitution.
-    /// - Restitution must be in [0.0 ..= 1.0], values outside tyhe range are clamped.
+    /// - Restitution must be in [0.0 ..= 1.0], values outside the range are clamped.
     /// - A reitution of 0.0 minimizes bouncing, higher values mean more bounce.
     #[inline]
     fn set_restitution(&mut self, mut restitution: f32) {

--- a/physx/src/shape.rs
+++ b/physx/src/shape.rs
@@ -62,9 +62,6 @@ unsafe impl<U, M: Material> UserData for PxShape<U, M> {
 impl<U, M: Material> Drop for PxShape<U, M> {
     fn drop(&mut self) {
         unsafe {
-            for material in self.get_materials_mut() {
-                drop_in_place(material as *mut _);
-            }
             drop_in_place(self.get_user_data_mut());
             use crate::base::RefCounted;
             self.release();

--- a/physx/tests/bug-180.rs
+++ b/physx/tests/bug-180.rs
@@ -2,49 +2,6 @@ use physx::{base::RefCounted, prelude::*};
 
 type PxMaterial = physx::material::PxMaterial<()>;
 type PxShape = physx::shape::PxShape<(), PxMaterial>;
-type PxArticulationLink = physx::articulation_link::PxArticulationLink<(), PxShape>;
-type PxRigidStatic = physx::rigid_static::PxRigidStatic<(), PxShape>;
-type PxRigidDynamic = physx::rigid_dynamic::PxRigidDynamic<(), PxShape>;
-
-/// Next up, the simulation event callbacks need to be defined, and possibly an
-/// allocator callback as well.
-struct OnCollision;
-impl CollisionCallback for OnCollision {
-    fn on_collision(
-        &mut self,
-        _header: &physx_sys::PxContactPairHeader,
-        _pairs: &[physx_sys::PxContactPair],
-    ) {
-    }
-}
-struct OnTrigger;
-impl TriggerCallback for OnTrigger {
-    fn on_trigger(&mut self, _pairs: &[physx_sys::PxTriggerPair]) {}
-}
-
-struct OnConstraintBreak;
-impl ConstraintBreakCallback for OnConstraintBreak {
-    fn on_constraint_break(&mut self, _constraints: &[physx_sys::PxConstraintInfo]) {}
-}
-struct OnWakeSleep;
-impl WakeSleepCallback<PxArticulationLink, PxRigidStatic, PxRigidDynamic> for OnWakeSleep {
-    fn on_wake_sleep(
-        &mut self,
-        _actors: &[&physx::actor::ActorMap<PxArticulationLink, PxRigidStatic, PxRigidDynamic>],
-        _is_waking: bool,
-    ) {
-    }
-}
-
-struct OnAdvance;
-impl AdvanceCallback<PxArticulationLink, PxRigidDynamic> for OnAdvance {
-    fn on_advance(
-        &self,
-        _actors: &[&physx::rigid_body::RigidBodyMap<PxArticulationLink, PxRigidDynamic>],
-        _transforms: &[PxTransform],
-    ) {
-    }
-}
 
 #[test]
 fn test_double_free() {

--- a/physx/tests/bug-180.rs
+++ b/physx/tests/bug-180.rs
@@ -1,0 +1,67 @@
+use physx::{base::RefCounted, prelude::*};
+
+type PxMaterial = physx::material::PxMaterial<()>;
+type PxShape = physx::shape::PxShape<(), PxMaterial>;
+type PxArticulationLink = physx::articulation_link::PxArticulationLink<(), PxShape>;
+type PxRigidStatic = physx::rigid_static::PxRigidStatic<(), PxShape>;
+type PxRigidDynamic = physx::rigid_dynamic::PxRigidDynamic<(), PxShape>;
+
+/// Next up, the simulation event callbacks need to be defined, and possibly an
+/// allocator callback as well.
+struct OnCollision;
+impl CollisionCallback for OnCollision {
+    fn on_collision(
+        &mut self,
+        _header: &physx_sys::PxContactPairHeader,
+        _pairs: &[physx_sys::PxContactPair],
+    ) {
+    }
+}
+struct OnTrigger;
+impl TriggerCallback for OnTrigger {
+    fn on_trigger(&mut self, _pairs: &[physx_sys::PxTriggerPair]) {}
+}
+
+struct OnConstraintBreak;
+impl ConstraintBreakCallback for OnConstraintBreak {
+    fn on_constraint_break(&mut self, _constraints: &[physx_sys::PxConstraintInfo]) {}
+}
+struct OnWakeSleep;
+impl WakeSleepCallback<PxArticulationLink, PxRigidStatic, PxRigidDynamic> for OnWakeSleep {
+    fn on_wake_sleep(
+        &mut self,
+        _actors: &[&physx::actor::ActorMap<PxArticulationLink, PxRigidStatic, PxRigidDynamic>],
+        _is_waking: bool,
+    ) {
+    }
+}
+
+struct OnAdvance;
+impl AdvanceCallback<PxArticulationLink, PxRigidDynamic> for OnAdvance {
+    fn on_advance(
+        &self,
+        _actors: &[&physx::rigid_body::RigidBodyMap<PxArticulationLink, PxRigidDynamic>],
+        _transforms: &[PxTransform],
+    ) {
+    }
+}
+
+#[test]
+fn test_double_free() {
+    let mut physics = PhysicsFoundation::<_, PxShape>::default();
+
+    let mut material = physics.create_material(0.5, 0.5, 0.6, ()).unwrap();
+    let geometry = PxBoxGeometry::new(1., 1., 1.);
+    let flags =
+        ShapeFlags::SceneQueryShape | ShapeFlags::SimulationShape | ShapeFlags::Visualization;
+
+    let shape = physics
+        .create_shape(&geometry, &mut [&mut material], false, flags, ())
+        .unwrap();
+
+    assert_eq!(material.get_reference_count(), 2);
+    drop(shape);
+
+    assert_eq!(material.get_reference_count(), 1);
+    drop(material);
+}


### PR DESCRIPTION
Fixes #180

@rlidwka  Correct analysis indeed, Physx internally decrements the ref count so no need for our wrappers to do so -- that leads to decrementing the ref-count twice. Do you have a bigger context where you'd be able to try this and ensure it now works?