### PR TITLE
Support building for Android on aarch64 macOS hosts

### DIFF
--- a/physx-sys/CHANGELOG.md
+++ b/physx-sys/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Added
+- [PR#216](https://github.com/EmbarkStudios/physx-rs/pull/216) Support building for Android on aarch64 macOS hosts
+
 ## [0.11.4] - 2023-09-18
 ### Added
 - [PR#212](https://github.com/EmbarkStudios/physx-rs/pull/212) Build physx with -fno-strict-aliasing.

--- a/physx-sys/build.rs
+++ b/physx-sys/build.rs
@@ -273,7 +273,7 @@ fn add_common(ctx: &mut Context) {
         let ndk_toolchain = match host_str {
             "x86_64-pc-windows-msvc" => "windows-x86_64",
             "x86_64-unknown-linux-gnu" => "linux-x86_64",
-            "x86_64-apple-darwin" => "darwin-x86_64",
+            "x86_64-apple-darwin" | "aarch64-apple-darwin" => "darwin-x86_64",
             _ => panic!(
                 "Host triple {} is unsupported for cross-compilation to Android",
                 host_str


### PR DESCRIPTION
The NDK puts universal binaries under the `darwin-x86_64` directory.

Verified that it works by patching Cargo.toml to use this branch while building on an M1 macbook.