### PR TITLE
chore: Fix clippy lint from 1.73

### DIFF
--- a/physx-sys/pxbind/src/dump.rs
+++ b/physx-sys/pxbind/src/dump.rs
@@ -67,7 +67,7 @@ pub fn get_ast(header: impl AsRef<std::path::Path>) -> anyhow::Result<Vec<u8>> {
         captured.status.success(),
         "clang++ failed to gather AST {:?}\n{}",
         captured.status,
-        String::from_utf8(captured.stderr).unwrap_or(String::new()),
+        String::from_utf8(captured.stderr).unwrap_or_default(),
     );
 
     Ok(captured.stdout)


### PR DESCRIPTION
Fixes the build error seen in https://github.com/EmbarkStudios/physx-rs/actions/runs/6461599287/job/17541604297?pr=216