### PR TITLE
physx-sys: Emit default values in FFI bindings for literal values

### DIFF
--- a/physx-sys/pxbind/src/consumer.rs
+++ b/physx-sys/pxbind/src/consumer.rs
@@ -100,6 +100,31 @@ pub enum Item {
         kind: Type,
     },
     ConstantExpr {
+        value: Option<String>,
+        #[serde(rename = "type")]
+        kind: Type,
+    },
+    CXXBoolLiteralExpr {
+        value: bool,
+        #[serde(rename = "type")]
+        kind: Type,
+    },
+    IntegerLiteral {
+        value: String,
+        #[serde(rename = "type")]
+        kind: Type,
+    },
+    FloatingLiteral {
+        value: String,
+        #[serde(rename = "type")]
+        kind: Type,
+    },
+    StringLiteral {
+        value: String,
+        #[serde(rename = "type")]
+        kind: Type,
+    },
+    UserDefinedLiteral {
         value: String,
         #[serde(rename = "type")]
         kind: Type,
@@ -111,7 +136,7 @@ pub enum Item {
     TemplateArgument {
         #[serde(rename = "type")]
         kind: Option<Type>,
-        value: Option<i32>,
+        value: Option<i64>,
     },
     RecordType {
         #[serde(rename = "type")]

--- a/physx-sys/pxbind/src/consumer/enums.rs
+++ b/physx-sys/pxbind/src/consumer/enums.rs
@@ -110,7 +110,9 @@ impl<'ast> super::AstConsumer<'ast> {
                             }
                         }
 
-                        return value.parse().context("failed to parse enum constant");
+                        if let Some(v) = value {
+                            return v.parse().context("failed to parse enum constant");
+                        }
                     }
                     _ => continue,
                 }

--- a/physx-sys/pxbind/src/generator/functions.rs
+++ b/physx-sys/pxbind/src/generator/functions.rs
@@ -190,8 +190,20 @@ impl<'ast> FuncBinding<'ast> {
         }
 
         let indent = Indent(level);
-
         let mut acc = String::new();
+
+        // write default values of params
+        let mut first_param = true;
+        for param in self.params.iter() {
+            if let Some(v) = &param.default_value {
+                if first_param {
+                    writesln!(acc, "{indent}///");
+                    first_param = false;
+                }
+                writesln!(acc, "{indent}/// {} = {}", param.name, v);
+            }
+        }
+
         writes!(acc, "{indent}pub fn {}(", self.name);
 
         for (i, param) in self.params.iter().enumerate() {


### PR DESCRIPTION
Hi, this is a simple fix for https://github.com/EmbarkStudios/physx-rs/issues/188

It generates comments for literal default values (ints, floats, ..) like this:

```
/// inflation = 1.01
pub fn PxActor_getWorldBounds(self_: *const PxActor, inflation: f32) -> PxBounds3;

/// inflation = 0
/// doubleSided = false
pub fn PxMeshQuery_sweep(unitDir: *const PxVec3, distance: f32, geom: *const PxGeometry, pose: *const PxTransform, triangleCount: u32, triangles: *const PxTriangle, sweepHit: *mut PxGeomSweepHit, hitFlags: PxHitFlags, cachedIndex: *const u32, inflation: f32, doubleSided: bool, queryFlags: PxGeometryQueryFlags) -> bool;

/// scaleMassProps = true
pub fn phys_PxScaleRigidActor(actor: *mut PxRigidActor, scale: f32, scaleMassProps: bool);
```


A totally different way of solving this would be to not care about the kind of AST node and use the range begin/end offset to read the source expression from the source code instead. But if almost all default values are simple values then this approach might be good enough.

Not really expecting you to merge this as is without changes, but at least it can serve as a starting point.

I haven't really written much rust before so let me know if there is something un-idiomatic.