### PR TITLE
Fix misalignment in examples

### DIFF
--- a/physx/examples/ball_physx.rs
+++ b/physx/examples/ball_physx.rs
@@ -22,7 +22,7 @@ type PxRigidDynamic = physx::rigid_dynamic::PxRigidDynamic<(), PxShape>;
 type PxArticulationReducedCoordinate =
     physx::articulation_reduced_coordinate::PxArticulationReducedCoordinate<(), PxArticulationLink>;
 type PxScene = physx::scene::PxScene<
-    (),
+    *const std::ffi::c_void,
     PxArticulationLink,
     PxRigidStatic,
     PxRigidDynamic,
@@ -86,7 +86,7 @@ fn main() {
         .create(SceneDescriptor {
             gravity: PxVec3::new(0.0, -9.81, 0.0),
             on_advance: Some(OnAdvance),
-            ..SceneDescriptor::new(())
+            ..SceneDescriptor::new(std::ptr::null())
         })
         .unwrap();
 

--- a/physx/examples/profiler.rs
+++ b/physx/examples/profiler.rs
@@ -9,7 +9,7 @@ type PxRigidDynamic = physx::rigid_dynamic::PxRigidDynamic<(), PxShape>;
 type PxArticulationReducedCoordinate =
     physx::articulation_reduced_coordinate::PxArticulationReducedCoordinate<(), PxArticulationLink>;
 type PxScene = physx::scene::PxScene<
-    (),
+    *const std::ffi::c_void,
     PxArticulationLink,
     PxRigidStatic,
     PxRigidDynamic,
@@ -111,7 +111,7 @@ fn main() {
         .create(SceneDescriptor {
             gravity: PxVec3::new(0.0, -9.81, 0.0),
             on_advance: Some(OnAdvance),
-            ..SceneDescriptor::new(())
+            ..SceneDescriptor::new(std::ptr::null())
         })
         .unwrap();
 


### PR DESCRIPTION
This fixes the examples that break if run in debug mode in more recent rust versions.